### PR TITLE
Polish README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # SkillRoute
 
-SkillRoute is a local-first skill catalog and router for agent builders. It indexes
-`SKILL.md` bundles, stores reviewed metadata in SQLite, models relationships as a
-small graph, and returns ranked skill plans with evidence and clarification
-questions when the match is uncertain.
+Local-first skill routing for agent builders.
+
+SkillRoute indexes full `SKILL.md` bundles, stores reviewed metadata in SQLite,
+and returns ranked skill plans with confidence, evidence, score breakdowns, and
+clarification prompts when the route is uncertain.
+
+![CI](https://github.com/erichare/skill-route/actions/workflows/ci.yml/badge.svg)
+
+## Why
+
+Most agents pick skills from a tiny description. SkillRoute gives them a real
+catalog: parsed skill bundles, facets, graph relationships, backend retrieval,
+golden-route evals, and inspectable routing traces.
 
 ## Quick Start
 
@@ -11,119 +20,59 @@ questions when the match is uncertain.
 uv run skillroute index --root examples/skills
 uv run skillroute route "Build an MCP server that exposes routing tools"
 uv run skillroute inspect mcp-server-patterns
+```
+
+The default catalog is `.skillroute/catalog.db`. Use `--catalog <path>` or
+`SKILLROUTE_CATALOG_PATH` when you want an explicit catalog.
+
+## Screenshots
+
+![SkillRoute route output](docs/assets/screenshot-route.svg)
+
+![SkillRoute trace inspection](docs/assets/screenshot-traces.svg)
+
+## What You Get
+
+- Hybrid routing over lexical metadata, local/remote retrieval, repo context,
+  and skill graph signals.
+- Local SQLite catalog with skills, excerpts, relationships, backend refs,
+  route traces, and eval cases.
+- Optional Astra DB Data API retrieval backend.
+- TypeScript MCP server exposing `skillroute.route`, `skillroute.search`, and
+  `skillroute.inspect_skill`.
+- CLI tools for indexing, routing, search, metadata review, backend status,
+  trace inspection, and golden-route evals.
+
+## Docs
+
+- [Getting Started](docs/getting-started.md)
+- [Astra Data API Backend](docs/astra-backend.md)
+- [Metadata Overlays](docs/metadata-overlays.md)
+- [Route Observability](docs/route-observability.md)
+- [MCP Server](docs/mcp-server.md)
+- [Golden Route Evals](docs/evals.md)
+- [Roadmap](docs/roadmap.md)
+
+## Core Commands
+
+```bash
+uv run skillroute search "Astra vector backend"
 uv run skillroute eval run --fresh --index-root examples/skills --cases examples/evals/golden_routes.json
-```
-
-The default catalog lives at `.skillroute/catalog.db` in the current directory.
-Use `--catalog <path>` or `SKILLROUTE_CATALOG_PATH` to point at another catalog.
-
-## Dogfooding Local Skills
-
-SkillRoute can discover the local skill roots used by Codex-style workflows:
-
-```bash
-uv run skillroute dogfood roots
-uv run skillroute dogfood index
-uv run skillroute route "Review a GitHub PR with exact file and line evidence"
-```
-
-The dogfood command looks for:
-
-- `~/.codex/skills`
-- `~/.agents/skills`
-- `~/.codex/plugins/cache`
-
-Use the example dogfood cases as a template for real routing regressions:
-
-```bash
-uv run skillroute eval run --fresh --index-root examples/skills --cases examples/evals/dogfood_routes.json
-```
-
-## Metadata Review
-
-Generate a reviewable overlay without editing source `SKILL.md` files:
-
-```bash
-uv run skillroute metadata suggest --root examples/skills
-uv run skillroute metadata review --root examples/skills
-```
-
-The default overlay path is `.skillroute/overlays/suggested.json` under the
-indexed root. Edit that JSON to mark `metadata.review_status` as `reviewed`,
-adjust tags/facets/relationships, then re-run `skillroute index --root <root>`.
-
-## Astra Data API Backend
-
-SkillRoute can sync the local catalog into an Astra DB Data API collection and
-query it with server-side vectorize search. Configure credentials with
-environment variables:
-
-```bash
-export ASTRA_DB_API_ENDPOINT="https://DATABASE_ID-REGION.apps.astra.datastax.com"
-export ASTRA_DB_APPLICATION_TOKEN="AstraCS:..."
-export SKILLROUTE_ASTRA_KEYSPACE="default_keyspace"
-export SKILLROUTE_ASTRA_COLLECTION="skillroute_skills"
-# Optional if your vectorize collection uses header authentication:
-export SKILLROUTE_ASTRA_EMBEDDING_API_KEY="..."
-```
-
-The default document shape includes `$vectorize`, so the target collection must
-be vectorize-enabled. You can pass collection options directly when creating it:
-
-```bash
-uv run skillroute backend astra create-collection --options-json '{"vector": {"service": {"provider": "YOUR_PROVIDER", "modelName": "YOUR_MODEL"}}}'
-uv run skillroute backend astra upsert
-uv run skillroute backend astra upsert --json --include-refs
-uv run skillroute backend astra search "build an MCP server"
-uv run skillroute route "build an MCP server" --backend astra
-```
-
-`skillroute route`, `skillroute search`, and the MCP `skillroute.route` /
-`skillroute.search` tools accept `backend: "astra"` to use Astra retrieval in
-the hybrid candidate set. Set `SKILLROUTE_BACKEND=astra` to make Astra the
-default backend for route/search calls.
-
-## Route Observability
-
-Check the selected retrieval backend without exposing secrets, and inspect
-recorded route decisions from the local catalog:
-
-```bash
 uv run skillroute backend status --backend astra
 uv run skillroute traces list
-uv run skillroute traces show 1
 ```
 
-## MCP Server
-
-The MCP package is a thin TypeScript stdio wrapper around the Python bridge:
-
-```bash
-cd mcp
-npm install
-npm run build
-node build/index.js
-```
-
-The server exposes:
-
-- `skillroute.route`
-- `skillroute.search`
-- `skillroute.inspect_skill`
-
-The wrapper invokes `python3 -m skillroute bridge ...` and sets `PYTHONPATH` to
-the repository `src` directory for local development.
-
-## Architecture
+## Current Shape
 
 - Python core: parsing, catalog persistence, routing, adapters, evals, and CLI.
-- SQLite catalog: durable local store for skills, excerpts, relationships,
-  backend refs, route traces, and eval cases.
-- TypeScript MCP: local stdio transport using the official MCP TypeScript SDK.
-- Retrieval adapters: local token backend now, with Astra DB/Data API and
-  LangChain-compatible adapter contracts ready for real remote indexing.
+- TypeScript MCP: local stdio transport around the Python bridge.
+- Retrieval adapters: local token backend by default, with Astra DB Data API and
+  LangChain-compatible adapter contracts.
 
-## Continuous Integration
+## Development
 
-GitHub Actions runs Python tests/lint, example golden-route evals, and the MCP
-build/typecheck/smoke suite on pushes and pull requests.
+```bash
+uv run --extra dev pytest
+uv run --extra dev ruff check .
+cd mcp && npm run build && npm run typecheck && npm run smoke
+```

--- a/docs/assets/screenshot-route.svg
+++ b/docs/assets/screenshot-route.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="430" viewBox="0 0 960 430" role="img" aria-labelledby="title desc">
+  <title id="title">SkillRoute route output screenshot</title>
+  <desc id="desc">Terminal-style screenshot showing ranked skill routing output with confidence, reasons, and evidence.</desc>
+  <rect width="960" height="430" rx="18" fill="#0f172a"/>
+  <rect x="0" y="0" width="960" height="44" rx="18" fill="#111827"/>
+  <circle cx="28" cy="22" r="6" fill="#ef4444"/>
+  <circle cx="50" cy="22" r="6" fill="#f59e0b"/>
+  <circle cx="72" cy="22" r="6" fill="#22c55e"/>
+  <text x="104" y="27" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">skillroute route</text>
+  <text x="28" y="82" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">$ uv run skillroute route "Build an MCP server"</text>
+  <text x="28" y="124" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16" font-weight="700">Ranked skills</text>
+  <text x="28" y="160" fill="#e2e8f0" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">1. mcp-server-patterns</text>
+  <text x="300" y="160" fill="#86efac" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">confidence=0.49</text>
+  <text x="28" y="190" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">Build MCP servers with Node and TypeScript using tools, resources, Zod schemas, and stdio.</text>
+  <text x="48" y="224" fill="#bae6fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">reason: Matched request terms against skill name, description, tags, or excerpts.</text>
+  <text x="48" y="252" fill="#bae6fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">reason: local-token retrieval returned this skill as a candidate.</text>
+  <text x="48" y="280" fill="#fde68a" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">evidence[description]: Build MCP servers with Node and TypeScript using tools...</text>
+  <rect x="28" y="314" width="904" height="70" rx="10" fill="#1e293b" stroke="#334155"/>
+  <text x="48" y="344" fill="#c4b5fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">score_breakdown</text>
+  <text x="48" y="370" fill="#e2e8f0" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">lexical=2.23  semantic=0.43  repo=0.00  graph=0.04  total=1.23</text>
+</svg>

--- a/docs/assets/screenshot-traces.svg
+++ b/docs/assets/screenshot-traces.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="430" viewBox="0 0 960 430" role="img" aria-labelledby="title desc">
+  <title id="title">SkillRoute route trace screenshot</title>
+  <desc id="desc">Terminal-style screenshot showing backend status and route trace inspection commands.</desc>
+  <rect width="960" height="430" rx="18" fill="#101820"/>
+  <rect x="0" y="0" width="960" height="44" rx="18" fill="#182433"/>
+  <circle cx="28" cy="22" r="6" fill="#ef4444"/>
+  <circle cx="50" cy="22" r="6" fill="#f59e0b"/>
+  <circle cx="72" cy="22" r="6" fill="#22c55e"/>
+  <text x="104" y="27" fill="#d1d5db" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">skillroute observability</text>
+  <text x="28" y="82" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">$ uv run skillroute backend status --backend astra</text>
+  <rect x="28" y="104" width="422" height="126" rx="10" fill="#17212f" stroke="#334155"/>
+  <text x="48" y="136" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">astra-data-api status=not_configured</text>
+  <text x="48" y="166" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">configured: false</text>
+  <text x="48" y="194" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">search_available: false</text>
+  <text x="48" y="218" fill="#a7f3d0" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13">token_configured=false endpoint_configured=false</text>
+  <text x="500" y="82" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">$ uv run skillroute traces list</text>
+  <rect x="500" y="104" width="432" height="126" rx="10" fill="#17212f" stroke="#334155"/>
+  <text x="520" y="136" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">1 2026-06-25 19:26:19 backend=local-token</text>
+  <text x="520" y="166" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">request: Build an MCP server</text>
+  <text x="520" y="194" fill="#fde68a" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">top: mcp-server-patterns confidence=0.49</text>
+  <text x="520" y="218" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">clarification_needed: false</text>
+  <text x="28" y="274" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">$ uv run skillroute traces show 1</text>
+  <rect x="28" y="296" width="904" height="88" rx="10" fill="#17212f" stroke="#334155"/>
+  <text x="48" y="326" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">Trace 1 | backend=local-token | request="Build an MCP server"</text>
+  <text x="48" y="354" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">1. mcp-server-patterns confidence=0.4916</text>
+  <text x="48" y="378" fill="#c4b5fd" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13">scores: lexical=2.2333 semantic=0.4333 repo=0.0 graph=0.04 total=1.229</text>
+</svg>

--- a/docs/astra-backend.md
+++ b/docs/astra-backend.md
@@ -1,0 +1,65 @@
+# Astra Data API Backend
+
+SkillRoute can sync the local catalog into an Astra DB Data API collection and
+use server-side vectorize search during route/search.
+
+## Configure
+
+```bash
+export ASTRA_DB_API_ENDPOINT="https://DATABASE_ID-REGION.apps.astra.datastax.com"
+export ASTRA_DB_APPLICATION_TOKEN="AstraCS:..."
+export SKILLROUTE_ASTRA_KEYSPACE="default_keyspace"
+export SKILLROUTE_ASTRA_COLLECTION="skillroute_skills"
+```
+
+Optional for vectorize collections that use header authentication:
+
+```bash
+export SKILLROUTE_ASTRA_EMBEDDING_API_KEY="..."
+```
+
+SkillRoute status output reports credential presence as booleans and does not
+print token values.
+
+## Create A Collection
+
+The default document shape includes `$vectorize`, so the target collection must
+be vectorize-enabled.
+
+```bash
+uv run skillroute backend astra create-collection \
+  --options-json '{"vector": {"service": {"provider": "YOUR_PROVIDER", "modelName": "YOUR_MODEL"}}}'
+```
+
+## Sync Skills
+
+```bash
+uv run skillroute backend astra upsert
+uv run skillroute backend astra upsert --json --include-refs
+```
+
+The upsert path keys documents by SkillRoute skill id and uses repeatable
+`findOneAndReplace` writes.
+
+## Search Or Route With Astra
+
+```bash
+uv run skillroute backend astra search "build an MCP server"
+uv run skillroute search "build an MCP server" --backend astra
+uv run skillroute route "build an MCP server" --backend astra
+```
+
+To make Astra the default route/search backend:
+
+```bash
+export SKILLROUTE_BACKEND=astra
+```
+
+## Status
+
+```bash
+uv run skillroute backend status --backend astra
+```
+
+This reports readiness, catalog skill count, backend ref counts, and
+non-secret Astra configuration details.

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -1,0 +1,51 @@
+# Golden Route Evals
+
+Golden-route evals protect routing behavior as scoring, metadata, and backend
+retrieval change.
+
+## Run Example Evals
+
+```bash
+uv run skillroute eval run \
+  --fresh \
+  --index-root examples/skills \
+  --cases examples/evals/golden_routes.json
+```
+
+Dogfood cases:
+
+```bash
+uv run skillroute eval run \
+  --fresh \
+  --index-root examples/skills \
+  --cases examples/evals/dogfood_routes.json
+```
+
+## Case Shape
+
+```json
+[
+  {
+    "id": "mcp-server-route",
+    "name": "mcp server route",
+    "request": "Build a TypeScript MCP stdio server with tools",
+    "expected_skill_names": ["mcp-server-patterns"],
+    "expect_clarification": false
+  }
+]
+```
+
+## What Evals Check
+
+- expected top skills by id or name
+- clarification behavior
+- route notes for failures
+
+## When To Add Cases
+
+Add a case when:
+
+- a route regresses
+- a new skill domain is introduced
+- scoring weights change
+- a backend adapter starts influencing candidate retrieval

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,62 @@
+# Getting Started
+
+SkillRoute is a local CLI and MCP server for routing agent requests to the right
+skills.
+
+## Install
+
+Use the repo directly during V1 development:
+
+```bash
+uv sync --extra dev
+```
+
+## Index Example Skills
+
+```bash
+uv run skillroute index --root examples/skills
+```
+
+This creates `.skillroute/catalog.db` in the current directory unless you pass
+`--catalog` or set `SKILLROUTE_CATALOG_PATH`.
+
+## Route A Request
+
+```bash
+uv run skillroute route "Build an MCP server that exposes routing tools"
+```
+
+The response includes ranked skills, confidence, reasons, evidence snippets,
+score components, suggested order, and clarification questions when needed.
+
+## Search And Inspect
+
+```bash
+uv run skillroute search "Astra vector backend"
+uv run skillroute inspect astra-vector-backend
+```
+
+Search is useful for catalog exploration. Inspect shows reviewed metadata,
+relationships, excerpts, source paths, and backend refs.
+
+## Dogfood Local Skills
+
+```bash
+uv run skillroute dogfood roots
+uv run skillroute dogfood index
+uv run skillroute route "Review a GitHub PR with exact file and line evidence"
+```
+
+Dogfood discovery checks:
+
+- `~/.codex/skills`
+- `~/.agents/skills`
+- `~/.codex/plugins/cache`
+
+## Next
+
+- Configure [Astra retrieval](astra-backend.md) when you want remote vectorize
+  search.
+- Use [metadata overlays](metadata-overlays.md) to review inferred facets and
+  relationships.
+- Run [golden-route evals](evals.md) before changing router scoring.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,66 @@
+# MCP Server
+
+SkillRoute includes a TypeScript stdio MCP server that wraps the Python bridge.
+
+## Build
+
+```bash
+cd mcp
+npm install
+npm run build
+```
+
+## Run
+
+```bash
+node build/index.js
+```
+
+The server sets `PYTHONPATH` to the repo `src` directory for local development
+and invokes:
+
+```bash
+python3 -m skillroute bridge <operation>
+```
+
+## Tools
+
+### `skillroute.route`
+
+Inputs:
+
+- `request`
+- `repo` optional
+- `catalog` optional
+- `backend` optional: `local` or `astra`
+- `limit` optional
+
+Returns ranked skills, reasons, confidence, evidence snippets, suggested order,
+and clarification questions.
+
+### `skillroute.search`
+
+Inputs:
+
+- `query`
+- `catalog` optional
+- `backend` optional: `local` or `astra`
+- `limit` optional
+
+Returns search rows with lexical/backend scores and evidence snippets.
+
+### `skillroute.inspect_skill`
+
+Inputs:
+
+- `skill_id`
+- `catalog` optional
+
+Returns metadata, facets, relationships, excerpts, references, and backend refs.
+
+## Smoke Test
+
+```bash
+cd mcp
+npm run smoke
+```

--- a/docs/metadata-overlays.md
+++ b/docs/metadata-overlays.md
@@ -1,0 +1,51 @@
+# Metadata Overlays
+
+SkillRoute keeps source skill files unchanged. Inferred or reviewed metadata
+lives in overlay JSON files beside the indexed skill root.
+
+## Suggest Metadata
+
+```bash
+uv run skillroute metadata suggest --root examples/skills
+```
+
+By default, suggestions are written to:
+
+```text
+examples/skills/.skillroute/overlays/suggested.json
+```
+
+## Review Metadata
+
+Edit the overlay to review descriptions, tags, facets, and relationships. Mark
+reviewed entries with:
+
+```json
+{
+  "metadata": {
+    "review_status": "reviewed"
+  }
+}
+```
+
+Then validate:
+
+```bash
+uv run skillroute metadata review --root examples/skills
+```
+
+## Reindex
+
+```bash
+uv run skillroute index --root examples/skills
+```
+
+Reindexing applies reviewed overlay metadata into the SQLite catalog.
+
+## Relationship Types
+
+- `requires`
+- `complements`
+- `conflicts`
+- `supersedes`
+- `same_domain`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,51 @@
+# Roadmap
+
+This is a working roadmap for the next implementation slices.
+
+## Slice 1: Real Catalog Fixtures
+
+Goal: index a broader local skill corpus and create realistic golden cases.
+
+- Add fixture generation for a mixed skill catalog.
+- Add route cases for overlapping domains, conflicts, and complements.
+- Add eval deltas that explain rank/confidence movement.
+
+## Slice 2: Backend-Aware Route Traces
+
+Goal: make traces explain retrieval behavior without reading raw JSON.
+
+- Show backend hit ids, raw scores, and normalized semantic scores.
+- Mark local-only fallback when remote backend is selected but not configured.
+- Add trace comparison between two route ids.
+
+## Slice 3: Astra Integration Contract
+
+Goal: make live Astra setup safer and easier to verify.
+
+- Add dry-run document preview before sync.
+- Add collection readiness checks.
+- Add small live smoke command gated by explicit credentials.
+
+## Slice 4: MCP Observability Tools
+
+Goal: expose debug surfaces to agents, not only humans at the CLI.
+
+- Add `skillroute.backend_status`.
+- Add `skillroute.list_traces`.
+- Add `skillroute.inspect_trace`.
+
+## Slice 5: Router Scoring Review
+
+Goal: make the hybrid score easier to tune.
+
+- Extract scoring weights into a config object.
+- Add per-component eval reporting.
+- Add confidence band assertions to golden cases.
+
+## Slice 6: Packaging Pass
+
+Goal: make local install and MCP registration smooth.
+
+- Add package metadata polish.
+- Add installation docs for agents.
+- Add a small release checklist.

--- a/docs/route-observability.md
+++ b/docs/route-observability.md
@@ -1,0 +1,51 @@
+# Route Observability
+
+SkillRoute records route decisions in the local SQLite catalog so scoring
+changes can be inspected and compared.
+
+## Backend Status
+
+```bash
+uv run skillroute backend status --backend local
+uv run skillroute backend status --backend astra
+```
+
+Status includes:
+
+- backend name
+- configured/readiness flags
+- search/write availability
+- catalog path and skill count
+- backend ref counts
+- non-secret backend details
+
+## List Recent Traces
+
+```bash
+uv run skillroute traces list
+uv run skillroute traces list --limit 5 --json
+```
+
+Each trace summary includes backend, request, top candidate, confidence, and
+whether clarification was recommended.
+
+## Show One Trace
+
+```bash
+uv run skillroute traces show 1
+uv run skillroute traces show 1 --json
+```
+
+The full trace contains the stored request, repo context, ranked candidates,
+evidence snippets, reasons, and score breakdowns.
+
+## Useful Workflow
+
+```bash
+uv run skillroute route "Build an MCP server"
+uv run skillroute traces list
+uv run skillroute traces show 1
+```
+
+Use trace inspection before and after scoring changes to understand why rank or
+confidence moved.


### PR DESCRIPTION
## Summary
- Replace the README with a concise front door and docs index
- Add focused sub-docs for getting started, Astra, metadata overlays, observability, MCP, evals, and roadmap
- Add two SVG terminal screenshots for route output and trace inspection

## Verification
- uv run --extra dev pytest
- uv run --extra dev ruff check .
- npm run build / typecheck / smoke in mcp
- golden and dogfood route evals