### PR TITLE
Add agent onboarding setup helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ golden-route evals, and inspectable routing traces.
 ## Quick Start
 
 ```bash
+./scripts/bootstrap.sh
+uv run skillroute route "Build an MCP server that exposes routing tools"
+```
+
+Manual setup is still just a few commands:
+
+```bash
 uv run skillroute index --root examples/skills
 uv run skillroute route "Build an MCP server that exposes routing tools"
 uv run skillroute inspect mcp-server-patterns
@@ -46,6 +53,7 @@ The default catalog is `.skillroute/catalog.db`. Use `--catalog <path>` or
 ## Docs
 
 - [Getting Started](docs/getting-started.md)
+- [Agent Setup](docs/agent-setup.md)
 - [Astra Data API Backend](docs/astra-backend.md)
 - [Metadata Overlays](docs/metadata-overlays.md)
 - [Route Observability](docs/route-observability.md)
@@ -56,6 +64,7 @@ The default catalog is `.skillroute/catalog.db`. Use `--catalog <path>` or
 ## Core Commands
 
 ```bash
+uv run skillroute mcp config --client codex
 uv run skillroute search "Astra vector backend"
 uv run skillroute eval run --fresh --index-root examples/skills --cases examples/evals/golden_routes.json
 uv run skillroute backend status --backend astra

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -1,0 +1,114 @@
+# Agent Setup
+
+SkillRoute exposes a local stdio MCP server, so agent clients can route skill
+requests without a hosted service.
+
+## One Command First
+
+```bash
+./scripts/bootstrap.sh
+```
+
+The bootstrap script:
+
+- installs the Python dev environment
+- installs Node dependencies for the MCP server
+- builds `mcp/build/index.js`
+- indexes the example skills into `.skillroute/catalog.db`
+- prints setup commands for Codex, Claude Code, and Claude Desktop
+
+## Codex
+
+Generate a reviewed setup command and TOML snippet:
+
+```bash
+uv run skillroute mcp config --client codex
+```
+
+Run the printed `codex mcp add ...` command, or paste the TOML into:
+
+```text
+~/.codex/config.toml
+```
+
+Codex stores MCP servers in `config.toml`, and the CLI and IDE extension share
+that config. See the official [Codex MCP docs](https://developers.openai.com/codex/mcp).
+
+## Claude Code
+
+Generate a Claude Code setup command:
+
+```bash
+uv run skillroute mcp config --client claude-code
+```
+
+The default scope is `user`, which makes SkillRoute available across your
+projects while keeping the config private to your machine.
+
+For a team-shared project config:
+
+```bash
+uv run skillroute mcp config --client claude-code --scope project
+```
+
+That emits a `.mcp.json`-compatible snippet. The generated snippet uses absolute
+local paths, so replace those with team-safe environment variables before
+checking it in. See the official [Claude Code MCP docs](https://code.claude.com/docs/en/mcp).
+
+## Claude Desktop
+
+Generate the JSON block:
+
+```bash
+uv run skillroute mcp config --client claude-desktop
+```
+
+Paste the generated `mcpServers` block into Claude Desktop's config file:
+
+```text
+macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json
+Windows: %APPDATA%\Claude\claude_desktop_config.json
+```
+
+Restart Claude Desktop after editing the file. See the official
+[local MCP server guide](https://modelcontextprotocol.io/docs/develop/connect-local-servers).
+
+## Codex Plugin Status
+
+V1 uses direct MCP setup because the server currently points at a local source
+checkout. That is the least surprising path for early users.
+
+The next packaging step is a Codex plugin that bundles:
+
+- `.codex-plugin/plugin.json`
+- `.mcp.json`
+- friendly assets and screenshots
+- a package entrypoint that does not require editing paths by hand
+
+Codex plugins can bundle MCP servers through an `.mcp.json` file, so the setup
+generator is intentionally close to that future shape. See the official
+[Codex plugin docs](https://developers.openai.com/codex/plugins/build).
+
+## Useful Options
+
+```bash
+uv run skillroute mcp config --client codex --backend astra
+uv run skillroute mcp config --client claude-code --catalog /path/to/catalog.db
+uv run skillroute mcp config --client claude-desktop --server-name skillroute-dev
+```
+
+Generated config includes only local paths and SkillRoute backend selection. Keep
+remote backend credentials in your shell or client-specific private config, not
+in checked-in project files.
+
+## Troubleshooting
+
+```bash
+./scripts/bootstrap.sh
+npm --prefix mcp run smoke
+uv run skillroute backend status --backend local
+uv run skillroute route "Build an MCP server"
+```
+
+If a client cannot start the server, regenerate config and check that
+`mcp/build/index.js` exists at the absolute path shown in the output.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,10 +5,21 @@ skills.
 
 ## Install
 
-Use the repo directly during V1 development:
+Fast path:
+
+```bash
+./scripts/bootstrap.sh
+```
+
+That installs the Python environment, installs and builds the MCP server, indexes
+the example skills, and prints copy-paste setup commands for Codex and Claude.
+
+Manual setup is also supported:
 
 ```bash
 uv sync --extra dev
+npm --prefix mcp install
+npm --prefix mcp run build
 ```
 
 ## Index Example Skills
@@ -55,6 +66,7 @@ Dogfood discovery checks:
 
 ## Next
 
+- Connect SkillRoute to Codex or Claude with [agent setup](agent-setup.md).
 - Configure [Astra retrieval](astra-backend.md) when you want remote vectorize
   search.
 - Use [metadata overlays](metadata-overlays.md) to review inferred facets and

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -10,6 +10,25 @@ npm install
 npm run build
 ```
 
+Or run the full local bootstrap:
+
+```bash
+./scripts/bootstrap.sh
+```
+
+## Client Setup
+
+Generate reviewed setup for your agent client:
+
+```bash
+uv run skillroute mcp config --client codex
+uv run skillroute mcp config --client claude-code
+uv run skillroute mcp config --client claude-desktop
+```
+
+See [Agent Setup](agent-setup.md) for client-specific paths, scopes, and plugin
+packaging notes.
+
 ## Run
 
 ```bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,10 +42,13 @@ Goal: make the hybrid score easier to tune.
 - Add per-component eval reporting.
 - Add confidence band assertions to golden cases.
 
-## Slice 6: Packaging Pass
+## Slice 6: Agent Onboarding And Packaging
 
 Goal: make local install and MCP registration smooth.
 
-- Add package metadata polish.
-- Add installation docs for agents.
-- Add a small release checklist.
+- Done: add a one-command bootstrap for local development.
+- Done: generate reviewed MCP setup for Codex, Claude Code, and Claude Desktop.
+- Done: document current setup paths and plugin packaging direction.
+- Next: add package metadata polish.
+- Next: add a Codex plugin package with `.codex-plugin/plugin.json` and `.mcp.json`.
+- Next: add a small release checklist.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+need_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need_command uv
+need_command node
+need_command npm
+
+echo "==> Installing Python dev environment"
+uv sync --extra dev
+
+echo "==> Installing MCP server dependencies"
+npm --prefix mcp install
+
+echo "==> Building MCP server"
+npm --prefix mcp run build
+
+echo "==> Indexing example skills"
+uv run skillroute index --root examples/skills
+
+echo "==> Checking local backend"
+uv run skillroute backend status --backend local
+
+cat <<'EOF'
+
+SkillRoute is ready.
+
+Try:
+  uv run skillroute route "Build an MCP server that exposes routing tools"
+  uv run skillroute inspect mcp-server-patterns
+
+Generate agent setup:
+  uv run skillroute mcp config --client codex
+  uv run skillroute mcp config --client claude-code
+  uv run skillroute mcp config --client claude-desktop
+EOF

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -14,6 +14,12 @@ from skillroute.catalog import Catalog, default_catalog_path
 from skillroute.dogfood import discover_default_skill_roots, index_default_skill_roots
 from skillroute.evals import run_golden_routes
 from skillroute.metadata import default_overlay_path, review_metadata_overlay, write_metadata_overlay
+from skillroute.mcp_setup import (
+    CLAUDE_SCOPE_CHOICES,
+    MCP_CLIENT_CHOICES,
+    build_mcp_setup,
+    render_mcp_setup,
+)
 from skillroute.models import to_jsonable
 from skillroute.routing import Router
 
@@ -162,6 +168,32 @@ def build_parser() -> argparse.ArgumentParser:
     astra_search_parser.add_argument("--limit", type=int, default=10)
     astra_search_parser.add_argument("--json", action="store_true", dest="as_json")
     astra_search_parser.set_defaults(func=cmd_backend_astra_search)
+
+    mcp_parser = subparsers.add_parser("mcp", help="Generate MCP client setup")
+    mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command", required=True)
+    mcp_config_parser = mcp_subparsers.add_parser(
+        "config",
+        help="Print SkillRoute MCP setup for Codex, Claude Code, or Claude Desktop",
+    )
+    mcp_config_parser.add_argument("--client", choices=MCP_CLIENT_CHOICES, required=True)
+    mcp_config_parser.add_argument("--repo-root", type=Path, default=None)
+    mcp_config_parser.add_argument(
+        "--catalog",
+        type=Path,
+        dest="mcp_catalog",
+        default=None,
+        help="Catalog path for generated MCP env. Can also be passed globally before mcp.",
+    )
+    add_backend_argument(mcp_config_parser)
+    mcp_config_parser.add_argument("--server-name", default="skillroute")
+    mcp_config_parser.add_argument(
+        "--scope",
+        choices=CLAUDE_SCOPE_CHOICES,
+        default="user",
+        help="Claude Code scope for generated claude mcp add commands.",
+    )
+    mcp_config_parser.add_argument("--json", action="store_true", dest="as_json")
+    mcp_config_parser.set_defaults(func=cmd_mcp_config)
 
     bridge_parser = subparsers.add_parser("bridge", help="JSON stdin/stdout bridge for MCP wrappers")
     bridge_parser.add_argument("operation", choices=["route", "search", "inspect"])
@@ -440,6 +472,21 @@ def cmd_backend_astra_search(args: argparse.Namespace) -> None:
         skill = catalog.get_skill(row["skill_id"])
         name = skill.name if skill else row["skill_id"]
         print(f"{name} ({row['skill_id']}) score={row['score']}")
+
+
+def cmd_mcp_config(args: argparse.Namespace) -> None:
+    payload = build_mcp_setup(
+        client=args.client,
+        repo_root=args.repo_root,
+        catalog=args.mcp_catalog or args.catalog,
+        backend=args.backend,
+        server_name=args.server_name,
+        claude_scope=args.scope,
+    )
+    if args.as_json:
+        print_json(payload)
+        return
+    print(render_mcp_setup(payload))
 
 
 def run_astra_command(operation):

--- a/src/skillroute/mcp_setup.py
+++ b/src/skillroute/mcp_setup.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+from skillroute.catalog import default_catalog_path
+
+
+MCP_CLIENT_CHOICES = ("codex", "claude-code", "claude-desktop")
+CLAUDE_SCOPE_CHOICES = ("local", "project", "user")
+
+
+def build_mcp_setup(
+    *,
+    client: str,
+    repo_root: Path | None = None,
+    catalog: Path | None = None,
+    backend: str | None = None,
+    server_name: str = "skillroute",
+    claude_scope: str = "user",
+) -> dict[str, Any]:
+    if client not in MCP_CLIENT_CHOICES:
+        valid = ", ".join(MCP_CLIENT_CHOICES)
+        raise ValueError(f"Unsupported MCP client {client!r}; expected one of: {valid}")
+    if claude_scope not in CLAUDE_SCOPE_CHOICES:
+        valid = ", ".join(CLAUDE_SCOPE_CHOICES)
+        raise ValueError(f"Unsupported Claude Code scope {claude_scope!r}; expected one of: {valid}")
+
+    resolved_repo_root = (repo_root or default_repo_root()).expanduser().resolve()
+    catalog_path = (catalog.expanduser().resolve() if catalog else default_catalog_path(resolved_repo_root))
+    selected_backend = (backend or os.environ.get("SKILLROUTE_BACKEND") or "local").strip().lower()
+    entrypoint = resolved_repo_root / "mcp" / "build" / "index.js"
+    env = {
+        "SKILLROUTE_CATALOG_PATH": str(catalog_path),
+        "SKILLROUTE_BACKEND": selected_backend,
+    }
+    server_config = {
+        "command": "node",
+        "args": [str(entrypoint)],
+        "env": env,
+    }
+    notes = [
+        "Run ./scripts/bootstrap.sh first if mcp/build/index.js does not exist.",
+        "The generated config points at this local checkout and catalog.",
+    ]
+    if not entrypoint.exists():
+        notes.append(f"MCP entrypoint not found yet: {entrypoint}")
+
+    payload: dict[str, Any] = {
+        "client": client,
+        "server_name": server_name,
+        "repo_root": str(resolved_repo_root),
+        "mcp_entrypoint": str(entrypoint),
+        "catalog": str(catalog_path),
+        "backend": selected_backend,
+        "server_config": server_config,
+        "notes": notes,
+    }
+
+    if client == "codex":
+        payload.update(
+            {
+                "install_command": shell_command(
+                    [
+                        "codex",
+                        "mcp",
+                        "add",
+                        server_name,
+                        "--env",
+                        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
+                        "--env",
+                        f"SKILLROUTE_BACKEND={selected_backend}",
+                        "--",
+                        "node",
+                        str(entrypoint),
+                    ]
+                ),
+                "config_path": "~/.codex/config.toml",
+                "config_format": "toml",
+                "config": codex_toml(server_name, entrypoint, resolved_repo_root, env),
+            }
+        )
+    elif client == "claude-code":
+        payload.update(
+            {
+                "scope": claude_scope,
+                "install_command": shell_command(
+                    [
+                        "claude",
+                        "mcp",
+                        "add",
+                        "--transport",
+                        "stdio",
+                        "--scope",
+                        claude_scope,
+                        "--env",
+                        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
+                        "--env",
+                        f"SKILLROUTE_BACKEND={selected_backend}",
+                        server_name,
+                        "--",
+                        "node",
+                        str(entrypoint),
+                    ]
+                ),
+                "config_path": claude_code_config_path(claude_scope),
+                "config_format": "json",
+                "config": {"mcpServers": {server_name: server_config}},
+            }
+        )
+    else:
+        payload.update(
+            {
+                "install_command": None,
+                "config_path": (
+                    "~/Library/Application Support/Claude/claude_desktop_config.json "
+                    "or %APPDATA%\\Claude\\claude_desktop_config.json"
+                ),
+                "config_format": "json",
+                "config": {"mcpServers": {server_name: server_config}},
+            }
+        )
+
+    return payload
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def shell_command(parts: list[str]) -> str:
+    return shlex.join(parts)
+
+
+def codex_toml(server_name: str, entrypoint: Path, repo_root: Path, env: dict[str, str]) -> str:
+    args = ", ".join(toml_string(part) for part in [str(entrypoint)])
+    env_pairs = ", ".join(f"{key} = {toml_string(value)}" for key, value in sorted(env.items()))
+    table_name = toml_table_name(server_name)
+    return "\n".join(
+        [
+            f"[mcp_servers.{table_name}]",
+            'command = "node"',
+            f"args = [{args}]",
+            f"cwd = {toml_string(str(repo_root))}",
+            f"env = {{ {env_pairs} }}",
+            "startup_timeout_sec = 20",
+            "tool_timeout_sec = 60",
+        ]
+    )
+
+
+def claude_code_config_path(scope: str) -> str:
+    if scope == "project":
+        return ".mcp.json"
+    return "~/.claude.json"
+
+
+def toml_table_name(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        return value
+    return toml_string(value)
+
+
+def toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def render_mcp_setup(payload: dict[str, Any]) -> str:
+    lines = [
+        f"SkillRoute MCP setup for {payload['client']}",
+        f"server: {payload['server_name']}",
+        f"catalog: {payload['catalog']}",
+        f"backend: {payload['backend']}",
+        "",
+    ]
+    if payload.get("install_command"):
+        lines.extend(["Install command:", payload["install_command"], ""])
+    lines.extend([f"Config path: {payload['config_path']}", f"Config format: {payload['config_format']}", ""])
+    lines.append("Config snippet:")
+    config = payload["config"]
+    if isinstance(config, str):
+        lines.append(config)
+    else:
+        lines.append(json.dumps(config, indent=2, sort_keys=True))
+    if payload.get("notes"):
+        lines.extend(["", "Notes:"])
+        lines.extend(f"- {note}" for note in payload["notes"])
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,6 +258,102 @@ def test_cli_search_uses_selected_astra_backend(
     assert payload[0]["backend_score"] == 0.94
 
 
+def test_cli_mcp_config_codex_outputs_install_command_and_toml(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    catalog_path = tmp_path / "catalog.db"
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "codex",
+            "--repo-root",
+            str(repo_root),
+            "--catalog",
+            str(catalog_path),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    entrypoint = repo_root / "mcp" / "build" / "index.js"
+    assert payload["client"] == "codex"
+    assert payload["config_path"] == "~/.codex/config.toml"
+    assert payload["install_command"].startswith("codex mcp add skillroute")
+    assert f"SKILLROUTE_CATALOG_PATH={catalog_path}" in payload["install_command"]
+    assert str(entrypoint) in payload["install_command"]
+    assert "[mcp_servers.skillroute]" in payload["config"]
+    assert f'args = ["{entrypoint}"]' in payload["config"]
+    assert f'SKILLROUTE_CATALOG_PATH = "{catalog_path}"' in payload["config"]
+    assert any("MCP entrypoint not found yet" in note for note in payload["notes"])
+
+
+def test_cli_mcp_config_claude_code_outputs_scoped_command_and_json(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "claude-code",
+            "--repo-root",
+            str(repo_root),
+            "--scope",
+            "project",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    server = payload["config"]["mcpServers"]["skillroute"]
+    assert payload["scope"] == "project"
+    assert payload["config_path"] == ".mcp.json"
+    assert "claude mcp add --transport stdio --scope project" in payload["install_command"]
+    assert server["command"] == "node"
+    assert server["args"] == [str(repo_root / "mcp" / "build" / "index.js")]
+    assert server["env"]["SKILLROUTE_BACKEND"] == "local"
+
+
+def test_cli_mcp_config_claude_desktop_prints_config_snippet(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    catalog_path = tmp_path / "catalog.db"
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "claude-desktop",
+            "--repo-root",
+            str(repo_root),
+            "--catalog",
+            str(catalog_path),
+            "--backend",
+            "astra",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert "SkillRoute MCP setup for claude-desktop" in output
+    assert "claude_desktop_config.json" in output
+    assert '"SKILLROUTE_BACKEND": "astra"' in output
+    assert str(repo_root / "mcp" / "build" / "index.js") in output
+
+
 def test_cli_backend_status_reports_astra_without_secrets(
     tmp_path: Path,
     fixture_skills_root: Path,


### PR DESCRIPTION
## Summary
- add a one-command bootstrap for local SkillRoute setup
- add `skillroute mcp config` for Codex, Claude Code, and Claude Desktop
- document agent setup paths, Claude scopes, and the Codex plugin packaging direction

## Verification
- `uv run --extra dev pytest`
- `uv run --extra dev ruff check .`
- `npm --prefix mcp run build`
- `npm --prefix mcp run typecheck`
- `npm --prefix mcp run smoke`
- `./scripts/bootstrap.sh`