### PR TITLE
Feature IBM Bob in agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The default catalog is `.skillroute/catalog.db`. Use `--catalog <path>` or
 ## Core Commands
 
 ```bash
+uv run skillroute mcp config --client ibm-bob
 uv run skillroute mcp config --client codex
 uv run skillroute search "Astra vector backend"
 uv run skillroute eval run --fresh --index-root examples/skills --cases examples/evals/golden_routes.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ golden-route evals, and inspectable routing traces.
 
 ## Quick Start
 
+One-line installer for IBM Bob:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+```
+
+It confirms each step, installs SkillRoute into `~/.skillroute/skill-route` by
+default, bootstraps the MCP server, and can write Bob's `~/.bob/mcp.json` config
+with a backup.
+
+Already in a checkout:
+
 ```bash
 ./scripts/bootstrap.sh
 uv run skillroute route "Build an MCP server that exposes routing tools"

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -5,11 +5,38 @@ requests without a hosted service.
 
 ## One Command First
 
+For a fresh IBM Bob setup:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+```
+
+The installer confirms each step, installs SkillRoute into
+`~/.skillroute/skill-route` by default, builds the MCP server, indexes starter
+skills, and offers to write Bob's MCP config with a timestamped backup.
+
+For unattended use:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash -s -- --yes
+```
+
+Useful installer options:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
+  | SKILLROUTE_INSTALL_DIR=/opt/skillroute bash
+
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash -s -- --ref main --no-bob-write
+```
+
+Already in a checkout:
+
 ```bash
 ./scripts/bootstrap.sh
 ```
 
-The bootstrap script:
+The installer and bootstrap script:
 
 - installs the Python dev environment
 - installs Node dependencies for the MCP server

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -15,7 +15,40 @@ The bootstrap script:
 - installs Node dependencies for the MCP server
 - builds `mcp/build/index.js`
 - indexes the example skills into `.skillroute/catalog.db`
-- prints setup commands for Codex, Claude Code, and Claude Desktop
+- prints setup commands for IBM Bob, Codex, Claude Code, and Claude Desktop
+
+## IBM Bob
+
+IBM Bob is the primary first integration for SkillRoute. Bob already supports MCP,
+and SkillRoute's local stdio server gives Bob three tools:
+
+- `skillroute.route`
+- `skillroute.search`
+- `skillroute.inspect_skill`
+
+Generate a Bob-ready `mcpServers` block:
+
+```bash
+uv run skillroute mcp config --client ibm-bob
+```
+
+Paste the generated JSON into one of Bob's MCP config files:
+
+```text
+Global:  ~/.bob/mcp.json
+Project: .bob/mcp.json
+```
+
+Use global config for your own machine. Use project config only when the paths
+are team-safe, for example through environment variables or a shared install
+location.
+
+In Bob, open the MCP settings panel and make sure MCP servers are enabled.
+SkillRoute does not add `alwaysAllow`; Bob should ask before using tools unless
+you explicitly change tool approval settings.
+
+See the official [IBM Bob MCP docs](https://bob.ibm.com/docs/ide/configuration/mcp/mcp-in-bob)
+and [transport guide](https://bob.ibm.com/docs/ide/configuration/mcp/server-transports).
 
 ## Codex
 
@@ -92,6 +125,7 @@ generator is intentionally close to that future shape. See the official
 ## Useful Options
 
 ```bash
+uv run skillroute mcp config --client ibm-bob --backend astra
 uv run skillroute mcp config --client codex --backend astra
 uv run skillroute mcp config --client claude-code --catalog /path/to/catalog.db
 uv run skillroute mcp config --client claude-desktop --server-name skillroute-dev

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,24 @@ skills.
 
 ## Install
 
-Fast path:
+One-line installer for IBM Bob:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+```
+
+The installer confirms each step before it clones or updates SkillRoute,
+installs dependencies, builds the MCP server, indexes starter skills, and writes
+or offers to write Bob MCP config. It installs to `~/.skillroute/skill-route` by
+default.
+
+For unattended local/dev use:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash -s -- --yes
+```
+
+Already in a checkout:
 
 ```bash
 ./scripts/bootstrap.sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,8 @@ Fast path:
 ```
 
 That installs the Python environment, installs and builds the MCP server, indexes
-the example skills, and prints copy-paste setup commands for Codex and Claude.
+the example skills, and prints copy-paste setup commands for IBM Bob, Codex, and
+Claude.
 
 Manual setup is also supported:
 
@@ -66,7 +67,7 @@ Dogfood discovery checks:
 
 ## Next
 
-- Connect SkillRoute to Codex or Claude with [agent setup](agent-setup.md).
+- Connect SkillRoute to IBM Bob, Codex, or Claude with [agent setup](agent-setup.md).
 - Configure [Astra retrieval](astra-backend.md) when you want remote vectorize
   search.
 - Use [metadata overlays](metadata-overlays.md) to review inferred facets and

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -21,6 +21,7 @@ Or run the full local bootstrap:
 Generate reviewed setup for your agent client:
 
 ```bash
+uv run skillroute mcp config --client ibm-bob
 uv run skillroute mcp config --client codex
 uv run skillroute mcp config --client claude-code
 uv run skillroute mcp config --client claude-desktop

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ Goal: make the hybrid score easier to tune.
 Goal: make local install and MCP registration smooth.
 
 - Done: add a one-command bootstrap for local development.
-- Done: generate reviewed MCP setup for Codex, Claude Code, and Claude Desktop.
+- Done: generate reviewed MCP setup for IBM Bob, Codex, Claude Code, and Claude Desktop.
 - Done: document current setup paths and plugin packaging direction.
 - Next: add package metadata polish.
 - Next: add a Codex plugin package with `.codex-plugin/plugin.json` and `.mcp.json`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,7 @@ Goal: make the hybrid score easier to tune.
 Goal: make local install and MCP registration smooth.
 
 - Done: add a one-command bootstrap for local development.
+- Done: add a prompted curl installer with IBM Bob setup.
 - Done: generate reviewed MCP setup for IBM Bob, Codex, Claude Code, and Claude Desktop.
 - Done: document current setup paths and plugin packaging direction.
 - Next: add package metadata polish.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -39,6 +39,7 @@ Try:
   uv run skillroute inspect mcp-server-patterns
 
 Generate agent setup:
+  uv run skillroute mcp config --client ibm-bob
   uv run skillroute mcp config --client codex
   uv run skillroute mcp config --client claude-code
   uv run skillroute mcp config --client claude-desktop

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${SKILLROUTE_REPO_URL:-https://github.com/erichare/skill-route.git}"
+REF="${SKILLROUTE_REF:-main}"
+INSTALL_DIR="${SKILLROUTE_INSTALL_DIR:-}"
+ASSUME_YES="${SKILLROUTE_ASSUME_YES:-0}"
+WRITE_BOB_CONFIG="${SKILLROUTE_WRITE_BOB_CONFIG:-prompt}"
+INDEX_LOCAL_SKILLS="${SKILLROUTE_INDEX_LOCAL_SKILLS:-prompt}"
+BOB_CONFIG_PATH="${SKILLROUTE_BOB_CONFIG_PATH:-$HOME/.bob/mcp.json}"
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  BLUE="$(printf '\033[38;5;27m')"
+  CYAN="$(printf '\033[36m')"
+  GREEN="$(printf '\033[32m')"
+  YELLOW="$(printf '\033[33m')"
+  BOLD="$(printf '\033[1m')"
+  RESET="$(printf '\033[0m')"
+else
+  BLUE=""
+  CYAN=""
+  GREEN=""
+  YELLOW=""
+  BOLD=""
+  RESET=""
+fi
+
+usage() {
+  cat <<'EOF'
+SkillRoute installer
+
+Usage:
+  scripts/install.sh [options]
+  curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+
+Options:
+  --yes                 Accept prompts.
+  --install-dir PATH    Install or update SkillRoute at PATH.
+  --repo URL            Git repository URL.
+  --ref REF             Git branch, tag, or ref. Defaults to main.
+  --no-bob-write        Do not write ~/.bob/mcp.json.
+  --help                Show this help.
+
+Environment:
+  SKILLROUTE_INSTALL_DIR
+  SKILLROUTE_REPO_URL
+  SKILLROUTE_REF
+  SKILLROUTE_ASSUME_YES=1
+  SKILLROUTE_WRITE_BOB_CONFIG=0|1|prompt
+  SKILLROUTE_INDEX_LOCAL_SKILLS=0|1|prompt
+  SKILLROUTE_BOB_CONFIG_PATH
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yes|-y)
+      ASSUME_YES=1
+      shift
+      ;;
+    --install-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "--install-dir requires a path" >&2
+        exit 1
+      fi
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --repo)
+      if [[ $# -lt 2 ]]; then
+        echo "--repo requires a URL" >&2
+        exit 1
+      fi
+      REPO_URL="$2"
+      shift 2
+      ;;
+    --ref)
+      if [[ $# -lt 2 ]]; then
+        echo "--ref requires a branch, tag, or ref" >&2
+        exit 1
+      fi
+      REF="$2"
+      shift 2
+      ;;
+    --no-bob-write)
+      WRITE_BOB_CONFIG=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+is_truthy() {
+  case "$1" in
+    1|true|TRUE|yes|YES|y|Y) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+say() {
+  printf '%b\n' "$*"
+}
+
+banner() {
+  say "${BLUE}${BOLD}"
+  cat <<'EOF'
+IBM Bob + SkillRoute
+Local skill routing for agentic development
+EOF
+  say "${RESET}"
+}
+
+step() {
+  say ""
+  say "${CYAN}${BOLD}==>${RESET} ${BOLD}$1${RESET}"
+}
+
+ok() {
+  say "${GREEN}[ok]${RESET} $1"
+}
+
+warn() {
+  say "${YELLOW}[warn]${RESET} $1"
+}
+
+die() {
+  say "${YELLOW}[error]${RESET} $1" >&2
+  exit 1
+}
+
+confirm() {
+  local prompt="$1"
+  local reply
+  if is_truthy "$ASSUME_YES"; then
+    say "${GREEN}[yes]${RESET} $prompt"
+    return 0
+  fi
+  if [[ ! -r /dev/tty ]]; then
+    die "No terminal is available for prompts. Re-run with --yes or SKILLROUTE_ASSUME_YES=1."
+  fi
+  printf '%b? %s [y/N] %b' "$BOLD" "$prompt" "$RESET" > /dev/tty
+  read -r reply < /dev/tty || return 1
+  case "$reply" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+should_do() {
+  local setting="$1"
+  local prompt="$2"
+  case "$setting" in
+    1|true|TRUE|yes|YES|y|Y) return 0 ;;
+    0|false|FALSE|no|NO|n|N) return 1 ;;
+    *) confirm "$prompt" ;;
+  esac
+}
+
+need_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "Missing required command: $1"
+  fi
+}
+
+run_confirmed() {
+  local label="$1"
+  shift
+  step "$label"
+  if confirm "$label"; then
+    "$@"
+    ok "$label"
+  else
+    warn "Skipped: $label"
+  fi
+}
+
+local_checkout_root() {
+  local source_path="${BASH_SOURCE[0]:-}"
+  local candidate
+  if [[ -n "$source_path" && -f "$source_path" ]]; then
+    candidate="$(cd "$(dirname "$source_path")/.." && pwd)"
+    if [[ -f "$candidate/pyproject.toml" && -d "$candidate/mcp" ]]; then
+      printf '%s\n' "$candidate"
+    fi
+  fi
+}
+
+ensure_clean_checkout() {
+  local dir="$1"
+  if ! git -C "$dir" diff --quiet || ! git -C "$dir" diff --cached --quiet; then
+    die "Existing checkout has local changes: $dir"
+  fi
+}
+
+prepare_checkout() {
+  local detected_root="$1"
+  local using_current="$2"
+
+  step "Prepare SkillRoute checkout"
+  if [[ "$using_current" == "1" ]]; then
+    ok "Using current checkout: $detected_root"
+    INSTALL_DIR="$detected_root"
+    return
+  fi
+
+  if [[ -d "$INSTALL_DIR/.git" ]]; then
+    if confirm "Update existing checkout at $INSTALL_DIR from $REF"; then
+      ensure_clean_checkout "$INSTALL_DIR"
+      git -C "$INSTALL_DIR" fetch origin "$REF"
+      git -C "$INSTALL_DIR" checkout "$REF" 2>/dev/null || git -C "$INSTALL_DIR" checkout -t "origin/$REF"
+      git -C "$INSTALL_DIR" pull --ff-only origin "$REF"
+      ok "Updated checkout: $INSTALL_DIR"
+    else
+      warn "Using existing checkout without updating: $INSTALL_DIR"
+    fi
+    return
+  fi
+
+  if [[ -e "$INSTALL_DIR" && -n "$(ls -A "$INSTALL_DIR" 2>/dev/null || true)" ]]; then
+    die "Install path exists and is not an empty directory: $INSTALL_DIR"
+  fi
+
+  if confirm "Clone SkillRoute into $INSTALL_DIR"; then
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+    git clone --branch "$REF" "$REPO_URL" "$INSTALL_DIR"
+    ok "Cloned SkillRoute: $INSTALL_DIR"
+  else
+    die "Cannot continue without a SkillRoute checkout."
+  fi
+}
+
+write_bob_config() {
+  local payload
+  payload="$(uv run skillroute mcp config --client ibm-bob --json)"
+  SKILLROUTE_MCP_PAYLOAD="$payload" BOB_CONFIG_PATH="$BOB_CONFIG_PATH" uv run python - <<'PY'
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import shutil
+from pathlib import Path
+
+target = Path(os.environ["BOB_CONFIG_PATH"]).expanduser()
+payload = json.loads(os.environ["SKILLROUTE_MCP_PAYLOAD"])
+server = payload["config"]["mcpServers"]["skillroute"]
+
+data: dict[str, object] = {}
+backup_path: Path | None = None
+if target.exists():
+    try:
+        data = json.loads(target.read_text(encoding="utf-8") or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Existing Bob MCP config is not valid JSON: {target}: {exc}") from exc
+    timestamp = dt.datetime.now().strftime("%Y%m%d%H%M%S")
+    backup_path = target.with_name(f"{target.name}.bak-{timestamp}")
+    shutil.copy2(target, backup_path)
+
+servers = data.setdefault("mcpServers", {})
+if not isinstance(servers, dict):
+    raise SystemExit(f"Bob MCP config has a non-object mcpServers field: {target}")
+servers["skillroute"] = server
+
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"Wrote {target}")
+if backup_path:
+    print(f"Backup {backup_path}")
+PY
+}
+
+main() {
+  local detected_root
+  local using_current=0
+
+  banner
+  say "This installer sets up SkillRoute locally and prepares IBM Bob MCP config."
+  say "Repository: $REPO_URL"
+  say "Ref:        $REF"
+
+  detected_root="$(local_checkout_root || true)"
+  if [[ -z "$INSTALL_DIR" && -n "$detected_root" ]]; then
+    INSTALL_DIR="$detected_root"
+    using_current=1
+  fi
+  if [[ -z "$INSTALL_DIR" ]]; then
+    INSTALL_DIR="$HOME/.skillroute/skill-route"
+  fi
+  say "Install:    $INSTALL_DIR"
+
+  step "Check prerequisites"
+  confirm "Check required commands: git, uv, node, npm" || die "Cannot continue without checking prerequisites."
+  need_command git
+  need_command uv
+  need_command node
+  need_command npm
+  ok "Required commands are available"
+
+  prepare_checkout "$detected_root" "$using_current"
+  cd "$INSTALL_DIR"
+
+  run_confirmed "Install Python environment with uv" uv sync --extra dev
+  run_confirmed "Install MCP server Node dependencies" npm --prefix mcp install
+  run_confirmed "Build MCP server" npm --prefix mcp run build
+  run_confirmed "Index example skills" uv run skillroute index --root examples/skills
+
+  step "Index local skill roots"
+  if should_do "$INDEX_LOCAL_SKILLS" "Index local Codex and agent skill roots if found"; then
+    uv run skillroute dogfood index
+    ok "Local skill-root indexing complete"
+  else
+    warn "Skipped local skill-root indexing"
+  fi
+
+  run_confirmed "Check local retrieval backend" uv run skillroute backend status --backend local
+
+  step "IBM Bob MCP setup"
+  if should_do "$WRITE_BOB_CONFIG" "Write or update IBM Bob MCP config at $BOB_CONFIG_PATH"; then
+    write_bob_config
+    ok "IBM Bob MCP config is ready"
+  else
+    warn "IBM Bob MCP config was not written"
+    say "Generate it later with:"
+    say "  cd $INSTALL_DIR"
+    say "  uv run skillroute mcp config --client ibm-bob"
+  fi
+
+  say ""
+  say "${BLUE}${BOLD}SkillRoute is ready for IBM Bob.${RESET}"
+  say "Try:"
+  say "  cd $INSTALL_DIR"
+  say "  uv run skillroute route \"Build an MCP server that exposes routing tools\""
+  say ""
+  say "Other agent setup:"
+  say "  uv run skillroute mcp config --client codex"
+  say "  uv run skillroute mcp config --client claude-code"
+  say "  uv run skillroute mcp config --client claude-desktop"
+}
+
+main "$@"

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -173,7 +173,7 @@ def build_parser() -> argparse.ArgumentParser:
     mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command", required=True)
     mcp_config_parser = mcp_subparsers.add_parser(
         "config",
-        help="Print SkillRoute MCP setup for Codex, Claude Code, or Claude Desktop",
+        help="Print SkillRoute MCP setup for IBM Bob, Codex, Claude Code, or Claude Desktop",
     )
     mcp_config_parser.add_argument("--client", choices=MCP_CLIENT_CHOICES, required=True)
     mcp_config_parser.add_argument("--repo-root", type=Path, default=None)

--- a/src/skillroute/mcp_setup.py
+++ b/src/skillroute/mcp_setup.py
@@ -10,7 +10,7 @@ from typing import Any
 from skillroute.catalog import default_catalog_path
 
 
-MCP_CLIENT_CHOICES = ("codex", "claude-code", "claude-desktop")
+MCP_CLIENT_CHOICES = ("ibm-bob", "codex", "claude-code", "claude-desktop")
 CLAUDE_SCOPE_CHOICES = ("local", "project", "user")
 
 
@@ -38,7 +38,7 @@ def build_mcp_setup(
         "SKILLROUTE_CATALOG_PATH": str(catalog_path),
         "SKILLROUTE_BACKEND": selected_backend,
     }
-    server_config = {
+    stdio_server_config = {
         "command": "node",
         "args": [str(entrypoint)],
         "env": env,
@@ -57,11 +57,28 @@ def build_mcp_setup(
         "mcp_entrypoint": str(entrypoint),
         "catalog": str(catalog_path),
         "backend": selected_backend,
-        "server_config": server_config,
+        "server_config": stdio_server_config,
         "notes": notes,
     }
 
-    if client == "codex":
+    if client == "ibm-bob":
+        payload.update(
+            {
+                "install_command": None,
+                "config_path": "~/.bob/mcp.json or .bob/mcp.json",
+                "config_format": "json",
+                "config": {
+                    "mcpServers": {
+                        server_name: {
+                            **stdio_server_config,
+                            "cwd": str(resolved_repo_root),
+                            "disabled": False,
+                        }
+                    }
+                },
+            }
+        )
+    elif client == "codex":
         payload.update(
             {
                 "install_command": shell_command(
@@ -109,7 +126,7 @@ def build_mcp_setup(
                 ),
                 "config_path": claude_code_config_path(claude_scope),
                 "config_format": "json",
-                "config": {"mcpServers": {server_name: server_config}},
+                "config": {"mcpServers": {server_name: stdio_server_config}},
             }
         )
     else:
@@ -121,7 +138,7 @@ def build_mcp_setup(
                     "or %APPDATA%\\Claude\\claude_desktop_config.json"
                 ),
                 "config_format": "json",
-                "config": {"mcpServers": {server_name: server_config}},
+                "config": {"mcpServers": {server_name: stdio_server_config}},
             }
         )
 
@@ -171,7 +188,7 @@ def toml_string(value: str) -> str:
 
 def render_mcp_setup(payload: dict[str, Any]) -> str:
     lines = [
-        f"SkillRoute MCP setup for {payload['client']}",
+        f"SkillRoute MCP setup for {client_display_name(payload['client'])}",
         f"server: {payload['server_name']}",
         f"catalog: {payload['catalog']}",
         f"backend: {payload['backend']}",
@@ -190,3 +207,13 @@ def render_mcp_setup(payload: dict[str, Any]) -> str:
         lines.extend(["", "Notes:"])
         lines.extend(f"- {note}" for note in payload["notes"])
     return "\n".join(lines)
+
+
+def client_display_name(client: str) -> str:
+    names = {
+        "ibm-bob": "IBM Bob",
+        "codex": "Codex",
+        "claude-code": "Claude Code",
+        "claude-desktop": "Claude Desktop",
+    }
+    return names.get(client, client)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,41 @@ def test_cli_mcp_config_codex_outputs_install_command_and_toml(
     assert any("MCP entrypoint not found yet" in note for note in payload["notes"])
 
 
+def test_cli_mcp_config_ibm_bob_outputs_bob_json(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    catalog_path = tmp_path / "catalog.db"
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "ibm-bob",
+            "--repo-root",
+            str(repo_root),
+            "--catalog",
+            str(catalog_path),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    server = payload["config"]["mcpServers"]["skillroute"]
+    assert payload["client"] == "ibm-bob"
+    assert payload["config_path"] == "~/.bob/mcp.json or .bob/mcp.json"
+    assert payload["install_command"] is None
+    assert server["command"] == "node"
+    assert server["args"] == [str(repo_root / "mcp" / "build" / "index.js")]
+    assert server["cwd"] == str(repo_root)
+    assert server["disabled"] is False
+    assert server["env"]["SKILLROUTE_CATALOG_PATH"] == str(catalog_path)
+    assert "alwaysAllow" not in server
+
+
 def test_cli_mcp_config_claude_code_outputs_scoped_command_and_json(
     tmp_path: Path,
     capsys,
@@ -348,7 +383,7 @@ def test_cli_mcp_config_claude_desktop_prints_config_snippet(
     )
 
     output = capsys.readouterr().out
-    assert "SkillRoute MCP setup for claude-desktop" in output
+    assert "SkillRoute MCP setup for Claude Desktop" in output
     assert "claude_desktop_config.json" in output
     assert '"SKILLROUTE_BACKEND": "astra"' in output
     assert str(repo_root / "mcp" / "build" / "index.js") in output

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_shell_scripts_have_valid_bash_syntax() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    for script in ("scripts/bootstrap.sh", "scripts/install.sh"):
+        subprocess.run(["bash", "-n", str(repo_root / script)], check=True)


### PR DESCRIPTION
## Summary
- add IBM Bob as the first supported MCP setup target
- generate Bob-specific `~/.bob/mcp.json` / `.bob/mcp.json` config with `cwd` and `disabled: false`
- update bootstrap and docs so Bob appears before Codex and Claude

## Verification
- `uv run skillroute mcp config --client ibm-bob --json`
- `uv run --extra dev pytest`
- `uv run --extra dev ruff check .`
- `npm --prefix mcp run build`
- `npm --prefix mcp run typecheck`
- `npm --prefix mcp run smoke`
- `./scripts/bootstrap.sh`