### PR TITLE
Make SkillRoute installer detect agent clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ golden-route evals, and inspectable routing traces.
 
 ## Quick Start
 
-One-line installer for IBM Bob:
+One-line SkillRoute installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
 ```
 
 It confirms each step, installs SkillRoute into `~/.skillroute/skill-route` by
-default, bootstraps the MCP server, and can write Bob's `~/.bob/mcp.json` config
-with a backup.
+default, bootstraps the MCP server, detects supported agent clients, and offers
+to set up each detected client with backups for edited JSON config files.
 
 Already in a checkout:
 
@@ -78,6 +78,10 @@ The default catalog is `.skillroute/catalog.db`. Use `--catalog <path>` or
 ```bash
 uv run skillroute mcp config --client ibm-bob
 uv run skillroute mcp config --client codex
+uv run skillroute mcp config --client claude-code
+uv run skillroute mcp config --client vscode
+uv run skillroute mcp config --client windsurf
+uv run skillroute mcp config --client cursor
 uv run skillroute search "Astra vector backend"
 uv run skillroute eval run --fresh --index-root examples/skills --cases examples/evals/golden_routes.json
 uv run skillroute backend status --backend astra

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -5,7 +5,7 @@ requests without a hosted service.
 
 ## One Command First
 
-For a fresh IBM Bob setup:
+For a fresh SkillRoute install:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
@@ -13,7 +13,9 @@ curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/i
 
 The installer confirms each step, installs SkillRoute into
 `~/.skillroute/skill-route` by default, builds the MCP server, indexes starter
-skills, and offers to write Bob's MCP config with a timestamped backup.
+skills, detects supported agent clients, and offers setup for each detected
+client. JSON config edits preserve unrelated servers and create timestamped
+backups.
 
 For unattended use:
 
@@ -27,8 +29,16 @@ Useful installer options:
 curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
   | SKILLROUTE_INSTALL_DIR=/opt/skillroute bash
 
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash -s -- --ref main --no-bob-write
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
+  | bash -s -- --clients codex,claude-code,vscode --yes
+
+curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
+  | SKILLROUTE_CLIENT_SETUP=0 bash
 ```
+
+Use `--no-client-setup` when you want detection output without config changes.
+Use `--clients auto`, `--clients all`, or a comma-separated list such as
+`--clients ibm-bob,codex,windsurf`.
 
 Already in a checkout:
 
@@ -42,7 +52,11 @@ The installer and bootstrap script:
 - installs Node dependencies for the MCP server
 - builds `mcp/build/index.js`
 - indexes the example skills into `.skillroute/catalog.db`
-- prints setup commands for IBM Bob, Codex, Claude Code, and Claude Desktop
+- prints setup commands for supported agent clients
+
+The installer can configure IBM Bob, Codex, Claude Code, Claude Desktop, VS Code,
+and Windsurf. Cursor is detected and shown as a snippet only until a stable
+official write target is confirmed.
 
 ## IBM Bob
 
@@ -133,6 +147,42 @@ Windows: %APPDATA%\Claude\claude_desktop_config.json
 Restart Claude Desktop after editing the file. See the official
 [local MCP server guide](https://modelcontextprotocol.io/docs/develop/connect-local-servers).
 
+## VS Code
+
+Generate a reviewed `code --add-mcp` command and profile snippet:
+
+```bash
+uv run skillroute mcp config --client vscode
+```
+
+The installer uses the VS Code CLI when `code` or `code-insiders` is available.
+Manual config uses a top-level `servers` object. See the official
+[VS Code MCP docs](https://code.visualstudio.com/docs/agent-customization/mcp-servers).
+
+## Windsurf
+
+Generate a Windsurf-ready `mcpServers` block:
+
+```bash
+uv run skillroute mcp config --client windsurf
+```
+
+The installer writes `~/.codeium/windsurf/mcp_config.json` when Windsurf is
+selected, preserving unrelated servers and creating a backup if the file already
+exists. See the official
+[Windsurf MCP docs](https://docs.devin.ai/desktop/cascade/mcp).
+
+## Cursor
+
+Generate a Cursor-compatible snippet:
+
+```bash
+uv run skillroute mcp config --client cursor
+```
+
+Cursor is detect-and-print only in V1. SkillRoute does not write Cursor config
+until the official config path and schema are stable enough to automate safely.
+
 ## Codex Plugin Status
 
 V1 uses direct MCP setup because the server currently points at a local source
@@ -156,6 +206,8 @@ uv run skillroute mcp config --client ibm-bob --backend astra
 uv run skillroute mcp config --client codex --backend astra
 uv run skillroute mcp config --client claude-code --catalog /path/to/catalog.db
 uv run skillroute mcp config --client claude-desktop --server-name skillroute-dev
+uv run skillroute mcp config --client vscode --server-name skillroute-dev
+uv run skillroute mcp config --client windsurf --catalog /path/to/catalog.db
 ```
 
 Generated config includes only local paths and SkillRoute backend selection. Keep

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,16 +5,16 @@ skills.
 
 ## Install
 
-One-line installer for IBM Bob:
+One-line SkillRoute installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
 ```
 
 The installer confirms each step before it clones or updates SkillRoute,
-installs dependencies, builds the MCP server, indexes starter skills, and writes
-or offers to write Bob MCP config. It installs to `~/.skillroute/skill-route` by
-default.
+installs dependencies, builds the MCP server, indexes starter skills, detects
+supported agent clients, and offers setup for each detected client. It installs
+to `~/.skillroute/skill-route` by default.
 
 For unattended local/dev use:
 
@@ -29,8 +29,7 @@ Already in a checkout:
 ```
 
 That installs the Python environment, installs and builds the MCP server, indexes
-the example skills, and prints copy-paste setup commands for IBM Bob, Codex, and
-Claude.
+the example skills, and prints copy-paste setup commands for supported clients.
 
 Manual setup is also supported:
 
@@ -84,7 +83,7 @@ Dogfood discovery checks:
 
 ## Next
 
-- Connect SkillRoute to IBM Bob, Codex, or Claude with [agent setup](agent-setup.md).
+- Connect SkillRoute to an agent client with [agent setup](agent-setup.md).
 - Configure [Astra retrieval](astra-backend.md) when you want remote vectorize
   search.
 - Use [metadata overlays](metadata-overlays.md) to review inferred facets and

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -25,6 +25,9 @@ uv run skillroute mcp config --client ibm-bob
 uv run skillroute mcp config --client codex
 uv run skillroute mcp config --client claude-code
 uv run skillroute mcp config --client claude-desktop
+uv run skillroute mcp config --client vscode
+uv run skillroute mcp config --client windsurf
+uv run skillroute mcp config --client cursor
 ```
 
 See [Agent Setup](agent-setup.md) for client-specific paths, scopes, and plugin

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,8 +47,8 @@ Goal: make the hybrid score easier to tune.
 Goal: make local install and MCP registration smooth.
 
 - Done: add a one-command bootstrap for local development.
-- Done: add a prompted curl installer with IBM Bob setup.
-- Done: generate reviewed MCP setup for IBM Bob, Codex, Claude Code, and Claude Desktop.
+- Done: add a prompted SkillRoute curl installer with detected-client setup.
+- Done: generate reviewed MCP setup for IBM Bob, Codex, Claude Code, Claude Desktop, VS Code, Windsurf, and Cursor.
 - Done: document current setup paths and plugin packaging direction.
 - Next: add package metadata polish.
 - Next: add a Codex plugin package with `.codex-plugin/plugin.json` and `.mcp.json`.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -43,4 +43,7 @@ Generate agent setup:
   uv run skillroute mcp config --client codex
   uv run skillroute mcp config --client claude-code
   uv run skillroute mcp config --client claude-desktop
+  uv run skillroute mcp config --client vscode
+  uv run skillroute mcp config --client windsurf
+  uv run skillroute mcp config --client cursor
 EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,9 +5,9 @@ REPO_URL="${SKILLROUTE_REPO_URL:-https://github.com/erichare/skill-route.git}"
 REF="${SKILLROUTE_REF:-main}"
 INSTALL_DIR="${SKILLROUTE_INSTALL_DIR:-}"
 ASSUME_YES="${SKILLROUTE_ASSUME_YES:-0}"
-WRITE_BOB_CONFIG="${SKILLROUTE_WRITE_BOB_CONFIG:-prompt}"
+CLIENT_SETUP="${SKILLROUTE_CLIENT_SETUP:-prompt}"
+CLIENTS="${SKILLROUTE_CLIENTS:-auto}"
 INDEX_LOCAL_SKILLS="${SKILLROUTE_INDEX_LOCAL_SKILLS:-prompt}"
-BOB_CONFIG_PATH="${SKILLROUTE_BOB_CONFIG_PATH:-$HOME/.bob/mcp.json}"
 
 if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
   BLUE="$(printf '\033[38;5;27m')"
@@ -34,11 +34,12 @@ Usage:
   curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
 
 Options:
-  --yes                 Accept prompts.
+  --yes                 Accept prompts, including detected client setup.
   --install-dir PATH    Install or update SkillRoute at PATH.
   --repo URL            Git repository URL.
   --ref REF             Git branch, tag, or ref. Defaults to main.
-  --no-bob-write        Do not write ~/.bob/mcp.json.
+  --clients SPEC        auto, all, or comma-separated client ids.
+  --no-client-setup     Detect clients but do not configure them.
   --help                Show this help.
 
 Environment:
@@ -46,9 +47,9 @@ Environment:
   SKILLROUTE_REPO_URL
   SKILLROUTE_REF
   SKILLROUTE_ASSUME_YES=1
-  SKILLROUTE_WRITE_BOB_CONFIG=0|1|prompt
+  SKILLROUTE_CLIENT_SETUP=prompt|0|1
+  SKILLROUTE_CLIENTS=auto|all|ibm-bob,codex,claude-code,claude-desktop,vscode,windsurf,cursor
   SKILLROUTE_INDEX_LOCAL_SKILLS=0|1|prompt
-  SKILLROUTE_BOB_CONFIG_PATH
 EOF
 }
 
@@ -82,8 +83,16 @@ while [[ $# -gt 0 ]]; do
       REF="$2"
       shift 2
       ;;
-    --no-bob-write)
-      WRITE_BOB_CONFIG=0
+    --clients)
+      if [[ $# -lt 2 ]]; then
+        echo "--clients requires auto, all, or a comma-separated client list" >&2
+        exit 1
+      fi
+      CLIENTS="$2"
+      shift 2
+      ;;
+    --no-client-setup)
+      CLIENT_SETUP=0
       shift
       ;;
     --help|-h)
@@ -112,8 +121,8 @@ say() {
 banner() {
   say "${BLUE}${BOLD}"
   cat <<'EOF'
-IBM Bob + SkillRoute
-Local skill routing for agentic development
+SkillRoute
+Local-first skill routing for agent builders
 EOF
   say "${RESET}"
 }
@@ -237,44 +246,26 @@ prepare_checkout() {
   fi
 }
 
-write_bob_config() {
-  local payload
-  payload="$(uv run skillroute mcp config --client ibm-bob --json)"
-  SKILLROUTE_MCP_PAYLOAD="$payload" BOB_CONFIG_PATH="$BOB_CONFIG_PATH" uv run python - <<'PY'
-from __future__ import annotations
-
-import datetime as dt
-import json
-import os
-import shutil
-from pathlib import Path
-
-target = Path(os.environ["BOB_CONFIG_PATH"]).expanduser()
-payload = json.loads(os.environ["SKILLROUTE_MCP_PAYLOAD"])
-server = payload["config"]["mcpServers"]["skillroute"]
-
-data: dict[str, object] = {}
-backup_path: Path | None = None
-if target.exists():
-    try:
-        data = json.loads(target.read_text(encoding="utf-8") or "{}")
-    except json.JSONDecodeError as exc:
-        raise SystemExit(f"Existing Bob MCP config is not valid JSON: {target}: {exc}") from exc
-    timestamp = dt.datetime.now().strftime("%Y%m%d%H%M%S")
-    backup_path = target.with_name(f"{target.name}.bak-{timestamp}")
-    shutil.copy2(target, backup_path)
-
-servers = data.setdefault("mcpServers", {})
-if not isinstance(servers, dict):
-    raise SystemExit(f"Bob MCP config has a non-object mcpServers field: {target}")
-servers["skillroute"] = server
-
-target.parent.mkdir(parents=True, exist_ok=True)
-target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-print(f"Wrote {target}")
-if backup_path:
-    print(f"Backup {backup_path}")
-PY
+run_client_setup() {
+  local setup_args
+  setup_args=(
+    "python"
+    "-m"
+    "skillroute.client_setup"
+    "setup"
+    "--repo-root"
+    "$INSTALL_DIR"
+    "--catalog"
+    "$INSTALL_DIR/.skillroute/catalog.db"
+    "--clients"
+    "$CLIENTS"
+    "--mode"
+    "$CLIENT_SETUP"
+  )
+  if is_truthy "$ASSUME_YES"; then
+    setup_args+=("--yes")
+  fi
+  uv run "${setup_args[@]}"
 }
 
 main() {
@@ -282,9 +273,10 @@ main() {
   local using_current=0
 
   banner
-  say "This installer sets up SkillRoute locally and prepares IBM Bob MCP config."
+  say "This installer sets up SkillRoute locally, then detects agent clients for MCP setup."
   say "Repository: $REPO_URL"
   say "Ref:        $REF"
+  say "Clients:    $CLIENTS"
 
   detected_root="$(local_checkout_root || true)"
   if [[ -z "$INSTALL_DIR" && -n "$detected_root" ]]; then
@@ -322,27 +314,23 @@ main() {
 
   run_confirmed "Check local retrieval backend" uv run skillroute backend status --backend local
 
-  step "IBM Bob MCP setup"
-  if should_do "$WRITE_BOB_CONFIG" "Write or update IBM Bob MCP config at $BOB_CONFIG_PATH"; then
-    write_bob_config
-    ok "IBM Bob MCP config is ready"
-  else
-    warn "IBM Bob MCP config was not written"
-    say "Generate it later with:"
-    say "  cd $INSTALL_DIR"
-    say "  uv run skillroute mcp config --client ibm-bob"
-  fi
+  step "Detect and set up agent clients"
+  run_client_setup
 
   say ""
-  say "${BLUE}${BOLD}SkillRoute is ready for IBM Bob.${RESET}"
+  say "${BLUE}${BOLD}SkillRoute is ready.${RESET}"
   say "Try:"
   say "  cd $INSTALL_DIR"
   say "  uv run skillroute route \"Build an MCP server that exposes routing tools\""
   say ""
-  say "Other agent setup:"
+  say "Manual client setup:"
+  say "  uv run skillroute mcp config --client ibm-bob"
   say "  uv run skillroute mcp config --client codex"
   say "  uv run skillroute mcp config --client claude-code"
   say "  uv run skillroute mcp config --client claude-desktop"
+  say "  uv run skillroute mcp config --client vscode"
+  say "  uv run skillroute mcp config --client windsurf"
+  say "  uv run skillroute mcp config --client cursor"
 }
 
 main "$@"

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -173,7 +173,7 @@ def build_parser() -> argparse.ArgumentParser:
     mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command", required=True)
     mcp_config_parser = mcp_subparsers.add_parser(
         "config",
-        help="Print SkillRoute MCP setup for IBM Bob, Codex, Claude Code, or Claude Desktop",
+        help="Print SkillRoute MCP setup for supported agent clients",
     )
     mcp_config_parser.add_argument("--client", choices=MCP_CLIENT_CHOICES, required=True)
     mcp_config_parser.add_argument("--repo-root", type=Path, default=None)

--- a/src/skillroute/client_setup.py
+++ b/src/skillroute/client_setup.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from skillroute.catalog import default_catalog_path
+from skillroute.mcp_setup import MCP_CLIENT_CHOICES, build_mcp_setup
+
+
+CLIENT_ORDER = (
+    "ibm-bob",
+    "codex",
+    "claude-code",
+    "claude-desktop",
+    "vscode",
+    "windsurf",
+    "cursor",
+)
+CLIENT_SETUP_CHOICES = ("prompt", "0", "1")
+
+
+@dataclass(frozen=True, slots=True)
+class ClientDetection:
+    id: str
+    name: str
+    detected: bool
+    reason: str
+    setup_method: str
+    command: str | None = None
+    config_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SetupResult:
+    client: str
+    status: str
+    message: str
+    backup_path: str | None = None
+
+
+class ClientEnvironment:
+    def __init__(
+        self,
+        *,
+        home: Path | None = None,
+        commands: dict[str, str | None] | None = None,
+        existing_paths: set[Path] | None = None,
+    ) -> None:
+        self.home = (home or Path.home()).expanduser()
+        self._commands = commands
+        self._existing_paths = {path.expanduser() for path in existing_paths} if existing_paths is not None else None
+
+    def which(self, command: str) -> str | None:
+        if self._commands is not None:
+            return self._commands.get(command)
+        return shutil.which(command)
+
+    def exists(self, path: Path) -> bool:
+        expanded = path.expanduser()
+        if self._existing_paths is not None:
+            return expanded in self._existing_paths
+        return expanded.exists()
+
+    def bob_config_path(self) -> Path:
+        return self.home / ".bob" / "mcp.json"
+
+    def claude_desktop_config_path(self) -> Path:
+        return self.home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+
+    def windsurf_config_path(self) -> Path:
+        return self.home / ".codeium" / "windsurf" / "mcp_config.json"
+
+    def cursor_config_path(self) -> Path:
+        return self.home / ".cursor" / "mcp.json"
+
+
+def detect_clients(env: ClientEnvironment | None = None) -> list[ClientDetection]:
+    env = env or ClientEnvironment()
+    detections = [
+        detect_bob(env),
+        detect_codex(env),
+        detect_claude_code(env),
+        detect_claude_desktop(env),
+        detect_vscode(env),
+        detect_windsurf(env),
+        detect_cursor(env),
+    ]
+    return sorted(detections, key=lambda detection: CLIENT_ORDER.index(detection.id))
+
+
+def detect_bob(env: ClientEnvironment) -> ClientDetection:
+    config_path = env.bob_config_path()
+    app_path = Path("/Applications/IBM Bob.app")
+    detected = env.exists(config_path) or env.exists(app_path)
+    reason = (
+        f"found {config_path if env.exists(config_path) else app_path}"
+        if detected
+        else "not found"
+    )
+    return ClientDetection("ibm-bob", "IBM Bob", detected, reason, "json_merge", config_path=str(config_path))
+
+
+def detect_codex(env: ClientEnvironment) -> ClientDetection:
+    command = env.which("codex")
+    return ClientDetection(
+        "codex",
+        "Codex",
+        bool(command),
+        f"found {command}" if command else "codex command not found",
+        "command",
+        command=command,
+    )
+
+
+def detect_claude_code(env: ClientEnvironment) -> ClientDetection:
+    command = env.which("claude")
+    return ClientDetection(
+        "claude-code",
+        "Claude Code",
+        bool(command),
+        f"found {command}" if command else "claude command not found",
+        "command",
+        command=command,
+    )
+
+
+def detect_claude_desktop(env: ClientEnvironment) -> ClientDetection:
+    config_path = env.claude_desktop_config_path()
+    app_path = Path("/Applications/Claude.app")
+    detected = env.exists(config_path) or env.exists(app_path)
+    reason = (
+        f"found {config_path if env.exists(config_path) else app_path}"
+        if detected
+        else "not found"
+    )
+    return ClientDetection(
+        "claude-desktop",
+        "Claude Desktop",
+        detected,
+        reason,
+        "json_merge",
+        config_path=str(config_path),
+    )
+
+
+def detect_vscode(env: ClientEnvironment) -> ClientDetection:
+    command = env.which("code") or env.which("code-insiders")
+    return ClientDetection(
+        "vscode",
+        "VS Code",
+        bool(command),
+        f"found {command}" if command else "code/code-insiders command not found",
+        "command",
+        command=command,
+    )
+
+
+def detect_windsurf(env: ClientEnvironment) -> ClientDetection:
+    config_path = env.windsurf_config_path()
+    app_path = Path("/Applications/Windsurf.app")
+    command = env.which("windsurf")
+    detected = bool(command) or env.exists(config_path) or env.exists(app_path)
+    if command:
+        reason = f"found {command}"
+    elif env.exists(config_path):
+        reason = f"found {config_path}"
+    elif env.exists(app_path):
+        reason = f"found {app_path}"
+    else:
+        reason = "not found"
+    return ClientDetection("windsurf", "Windsurf", detected, reason, "json_merge", config_path=str(config_path))
+
+
+def detect_cursor(env: ClientEnvironment) -> ClientDetection:
+    config_path = env.cursor_config_path()
+    app_path = Path("/Applications/Cursor.app")
+    command = env.which("cursor")
+    detected = bool(command) or env.exists(config_path) or env.exists(app_path)
+    if command:
+        reason = f"found {command}"
+    elif env.exists(config_path):
+        reason = f"found {config_path}"
+    elif env.exists(app_path):
+        reason = f"found {app_path}"
+    else:
+        reason = "not found"
+    return ClientDetection(
+        "cursor",
+        "Cursor",
+        detected,
+        reason,
+        "print_only",
+        command=command,
+        config_path=str(config_path),
+    )
+
+
+def select_clients(client_spec: str, detections: list[ClientDetection]) -> list[ClientDetection]:
+    by_id = {detection.id: detection for detection in detections}
+    if client_spec == "auto":
+        return [detection for detection in detections if detection.detected]
+    if client_spec == "all":
+        return detections
+    requested = [client.strip() for client in client_spec.split(",") if client.strip()]
+    unknown = sorted(set(requested) - set(MCP_CLIENT_CHOICES))
+    if unknown:
+        valid = ", ".join(MCP_CLIENT_CHOICES)
+        raise SystemExit(f"Unknown client(s): {', '.join(unknown)}. Expected: auto, all, or one of {valid}.")
+    return [by_id[client] for client in requested]
+
+
+def apply_client_setup(
+    detection: ClientDetection,
+    *,
+    repo_root: Path,
+    catalog: Path | None = None,
+    backend: str | None = None,
+    server_name: str = "skillroute",
+    yes: bool = False,
+    mode: str = "prompt",
+) -> SetupResult:
+    if mode == "0":
+        return SetupResult(detection.id, "skipped", "client setup disabled")
+    payload = build_mcp_setup(
+        client=detection.id,
+        repo_root=repo_root,
+        catalog=catalog,
+        backend=backend,
+        server_name=server_name,
+    )
+    if payload["setup_method"] == "print_only":
+        return SetupResult(detection.id, "printed", json.dumps(payload["config"], indent=2, sort_keys=True))
+    if mode == "prompt" and not yes and not confirm(f"Set up {detection.name} for SkillRoute"):
+        return SetupResult(detection.id, "skipped", "user skipped setup")
+    if payload["setup_method"] == "command":
+        if not detection.detected:
+            return SetupResult(detection.id, "skipped", detection.reason)
+        command_parts = list(payload["install_command_parts"])
+        if detection.id == "vscode" and detection.command:
+            command_parts[0] = detection.command
+        subprocess.run(command_parts, check=True)
+        return SetupResult(detection.id, "configured", payload["install_command"])
+    if detection.config_path is None:
+        return SetupResult(detection.id, "skipped", "no config path available")
+    backup_path = merge_json_config(Path(detection.config_path), payload["config"])
+    message = f"wrote {detection.config_path}"
+    return SetupResult(detection.id, "configured", message, backup_path=str(backup_path) if backup_path else None)
+
+
+def merge_json_config(path: Path, incoming: dict[str, Any]) -> Path | None:
+    path = path.expanduser()
+    existing: dict[str, Any] = {}
+    backup_path: Path | None = None
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8") or "{}")
+        if not isinstance(existing, dict):
+            raise ValueError(f"Existing config is not a JSON object: {path}")
+        timestamp = dt.datetime.now().strftime("%Y%m%d%H%M%S")
+        backup_path = path.with_name(f"{path.name}.bak-{timestamp}")
+        shutil.copy2(path, backup_path)
+
+    for key, value in incoming.items():
+        if isinstance(value, dict):
+            target = existing.setdefault(key, {})
+            if not isinstance(target, dict):
+                raise ValueError(f"Existing config field is not an object: {key}")
+            target.update(value)
+        else:
+            existing[key] = value
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return backup_path
+
+
+def confirm(prompt: str) -> bool:
+    try:
+        tty = open("/dev/tty", "r+", encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit("No terminal is available for prompts. Re-run with --yes or SKILLROUTE_CLIENT_SETUP=1.") from exc
+    with tty:
+        tty.write(f"? {prompt} [y/N] ")
+        tty.flush()
+        reply = tty.readline().strip().lower()
+    return reply in {"y", "yes"}
+
+
+def print_detection_summary(detections: list[ClientDetection]) -> None:
+    print("Detected agent clients:")
+    for detection in detections:
+        marker = "found" if detection.detected else "missing"
+        print(f"- {detection.name}: {marker} ({detection.reason})")
+
+
+def run_setup_command(args: argparse.Namespace) -> None:
+    env = ClientEnvironment()
+    detections = detect_clients(env)
+    print_detection_summary(detections)
+    selected = select_clients(args.clients, detections)
+    if not selected:
+        print("No clients selected for setup.")
+        return
+    repo_root = args.repo_root.expanduser().resolve()
+    catalog = args.catalog.expanduser().resolve() if args.catalog else default_catalog_path(repo_root)
+    for detection in selected:
+        if args.clients == "auto" and not detection.detected:
+            continue
+        result = apply_client_setup(
+            detection,
+            repo_root=repo_root,
+            catalog=catalog,
+            backend=args.backend,
+            yes=args.yes,
+            mode=args.mode,
+        )
+        print(f"{detection.name}: {result.status} - {result.message}")
+        if result.backup_path:
+            print(f"{detection.name}: backup - {result.backup_path}")
+
+
+def run_detect_command(args: argparse.Namespace) -> None:
+    detections = detect_clients(ClientEnvironment())
+    if args.as_json:
+        print(json.dumps([asdict(detection) for detection in detections], indent=2, sort_keys=True))
+        return
+    print_detection_summary(detections)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m skillroute.client_setup")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    detect_parser = subparsers.add_parser("detect", help="Detect supported agent clients")
+    detect_parser.add_argument("--json", action="store_true", dest="as_json")
+    detect_parser.set_defaults(func=run_detect_command)
+
+    setup_parser = subparsers.add_parser("setup", help="Detect and optionally configure agent clients")
+    setup_parser.add_argument("--repo-root", type=Path, required=True)
+    setup_parser.add_argument("--catalog", type=Path, default=None)
+    setup_parser.add_argument("--backend", default=None)
+    setup_parser.add_argument("--clients", default="auto")
+    setup_parser.add_argument("--mode", choices=CLIENT_SETUP_CHOICES, default="prompt")
+    setup_parser.add_argument("--yes", action="store_true")
+    setup_parser.set_defaults(func=run_setup_command)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/skillroute/mcp_setup.py
+++ b/src/skillroute/mcp_setup.py
@@ -10,7 +10,15 @@ from typing import Any
 from skillroute.catalog import default_catalog_path
 
 
-MCP_CLIENT_CHOICES = ("ibm-bob", "codex", "claude-code", "claude-desktop")
+MCP_CLIENT_CHOICES = (
+    "ibm-bob",
+    "codex",
+    "claude-code",
+    "claude-desktop",
+    "vscode",
+    "windsurf",
+    "cursor",
+)
 CLAUDE_SCOPE_CHOICES = ("local", "project", "user")
 
 
@@ -65,8 +73,10 @@ def build_mcp_setup(
         payload.update(
             {
                 "install_command": None,
+                "install_command_parts": None,
                 "config_path": "~/.bob/mcp.json or .bob/mcp.json",
                 "config_format": "json",
+                "setup_method": "json_merge",
                 "config": {
                     "mcpServers": {
                         server_name: {
@@ -79,53 +89,72 @@ def build_mcp_setup(
             }
         )
     elif client == "codex":
+        command_parts = codex_command_parts(server_name, catalog_path, selected_backend, entrypoint)
         payload.update(
             {
-                "install_command": shell_command(
-                    [
-                        "codex",
-                        "mcp",
-                        "add",
-                        server_name,
-                        "--env",
-                        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
-                        "--env",
-                        f"SKILLROUTE_BACKEND={selected_backend}",
-                        "--",
-                        "node",
-                        str(entrypoint),
-                    ]
-                ),
+                "install_command": shell_command(command_parts),
+                "install_command_parts": command_parts,
                 "config_path": "~/.codex/config.toml",
                 "config_format": "toml",
+                "setup_method": "command",
                 "config": codex_toml(server_name, entrypoint, resolved_repo_root, env),
             }
         )
     elif client == "claude-code":
+        command_parts = claude_code_command_parts(
+            server_name,
+            catalog_path,
+            selected_backend,
+            entrypoint,
+            claude_scope,
+        )
         payload.update(
             {
                 "scope": claude_scope,
-                "install_command": shell_command(
-                    [
-                        "claude",
-                        "mcp",
-                        "add",
-                        "--transport",
-                        "stdio",
-                        "--scope",
-                        claude_scope,
-                        "--env",
-                        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
-                        "--env",
-                        f"SKILLROUTE_BACKEND={selected_backend}",
-                        server_name,
-                        "--",
-                        "node",
-                        str(entrypoint),
-                    ]
-                ),
+                "install_command": shell_command(command_parts),
+                "install_command_parts": command_parts,
                 "config_path": claude_code_config_path(claude_scope),
                 "config_format": "json",
+                "setup_method": "command",
+                "config": {"mcpServers": {server_name: stdio_server_config}},
+            }
+        )
+    elif client == "claude-desktop":
+        payload.update(
+            {
+                "install_command": None,
+                "install_command_parts": None,
+                "config_path": (
+                    "~/Library/Application Support/Claude/claude_desktop_config.json "
+                    "or %APPDATA%\\Claude\\claude_desktop_config.json"
+                ),
+                "config_format": "json",
+                "setup_method": "json_merge",
+                "config": {"mcpServers": {server_name: stdio_server_config}},
+            }
+        )
+    elif client == "vscode":
+        server_config = {"name": server_name, **stdio_server_config}
+        command_parts = ["code", "--add-mcp", json.dumps(server_config, sort_keys=True)]
+        payload.update(
+            {
+                "install_command": shell_command(command_parts),
+                "install_command_parts": command_parts,
+                "config_path": "VS Code user profile mcp.json",
+                "config_format": "json",
+                "setup_method": "command",
+                "config": {"servers": {server_name: stdio_server_config}},
+                "server_config": server_config,
+            }
+        )
+    elif client == "windsurf":
+        payload.update(
+            {
+                "install_command": None,
+                "install_command_parts": None,
+                "config_path": "~/.codeium/windsurf/mcp_config.json",
+                "config_format": "json",
+                "setup_method": "json_merge",
                 "config": {"mcpServers": {server_name: stdio_server_config}},
             }
         )
@@ -133,12 +162,15 @@ def build_mcp_setup(
         payload.update(
             {
                 "install_command": None,
-                "config_path": (
-                    "~/Library/Application Support/Claude/claude_desktop_config.json "
-                    "or %APPDATA%\\Claude\\claude_desktop_config.json"
-                ),
+                "install_command_parts": None,
+                "config_path": "Cursor MCP settings",
                 "config_format": "json",
+                "setup_method": "print_only",
                 "config": {"mcpServers": {server_name: stdio_server_config}},
+                "notes": [
+                    *payload["notes"],
+                    "Cursor setup is snippet-only until a stable official write target is confirmed.",
+                ],
             }
         )
 
@@ -151,6 +183,53 @@ def default_repo_root() -> Path:
 
 def shell_command(parts: list[str]) -> str:
     return shlex.join(parts)
+
+
+def codex_command_parts(
+    server_name: str,
+    catalog_path: Path,
+    selected_backend: str,
+    entrypoint: Path,
+) -> list[str]:
+    return [
+        "codex",
+        "mcp",
+        "add",
+        server_name,
+        "--env",
+        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
+        "--env",
+        f"SKILLROUTE_BACKEND={selected_backend}",
+        "--",
+        "node",
+        str(entrypoint),
+    ]
+
+
+def claude_code_command_parts(
+    server_name: str,
+    catalog_path: Path,
+    selected_backend: str,
+    entrypoint: Path,
+    claude_scope: str,
+) -> list[str]:
+    return [
+        "claude",
+        "mcp",
+        "add",
+        "--transport",
+        "stdio",
+        "--scope",
+        claude_scope,
+        "--env",
+        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
+        "--env",
+        f"SKILLROUTE_BACKEND={selected_backend}",
+        server_name,
+        "--",
+        "node",
+        str(entrypoint),
+    ]
 
 
 def codex_toml(server_name: str, entrypoint: Path, repo_root: Path, env: dict[str, str]) -> str:
@@ -215,5 +294,8 @@ def client_display_name(client: str) -> str:
         "codex": "Codex",
         "claude-code": "Claude Code",
         "claude-desktop": "Claude Desktop",
+        "vscode": "VS Code",
+        "cursor": "Cursor",
+        "windsurf": "Windsurf",
     }
     return names.get(client, client)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,6 +389,94 @@ def test_cli_mcp_config_claude_desktop_prints_config_snippet(
     assert str(repo_root / "mcp" / "build" / "index.js") in output
 
 
+def test_cli_mcp_config_vscode_outputs_add_mcp_command(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    catalog_path = tmp_path / "catalog.db"
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "vscode",
+            "--repo-root",
+            str(repo_root),
+            "--catalog",
+            str(catalog_path),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["client"] == "vscode"
+    assert payload["setup_method"] == "command"
+    assert payload["install_command"].startswith("code --add-mcp")
+    assert payload["install_command_parts"][0:2] == ["code", "--add-mcp"]
+    add_payload = json.loads(payload["install_command_parts"][2])
+    assert add_payload["name"] == "skillroute"
+    assert add_payload["command"] == "node"
+    assert add_payload["args"] == [str(repo_root / "mcp" / "build" / "index.js")]
+    assert payload["config"]["servers"]["skillroute"]["env"]["SKILLROUTE_CATALOG_PATH"] == str(catalog_path)
+
+
+def test_cli_mcp_config_windsurf_outputs_config_path(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "windsurf",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    server = payload["config"]["mcpServers"]["skillroute"]
+    assert payload["client"] == "windsurf"
+    assert payload["setup_method"] == "json_merge"
+    assert payload["config_path"] == "~/.codeium/windsurf/mcp_config.json"
+    assert server["command"] == "node"
+    assert server["args"] == [str(repo_root / "mcp" / "build" / "index.js")]
+
+
+def test_cli_mcp_config_cursor_is_print_only(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    main(
+        [
+            "mcp",
+            "config",
+            "--client",
+            "cursor",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["client"] == "cursor"
+    assert payload["setup_method"] == "print_only"
+    assert payload["install_command"] is None
+    assert any("snippet-only" in note for note in payload["notes"])
+
+
 def test_cli_backend_status_reports_astra_without_secrets(
     tmp_path: Path,
     fixture_skills_root: Path,

--- a/tests/test_client_setup.py
+++ b/tests/test_client_setup.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from skillroute.client_setup import (
+    ClientDetection,
+    ClientEnvironment,
+    apply_client_setup,
+    detect_clients,
+    merge_json_config,
+    select_clients,
+)
+
+
+def test_detect_clients_uses_commands_and_paths(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    bob_config = home / ".bob" / "mcp.json"
+    windsurf_config = home / ".codeium" / "windsurf" / "mcp_config.json"
+    env = ClientEnvironment(
+        home=home,
+        commands={
+            "codex": "/usr/local/bin/codex",
+            "claude": None,
+            "code": None,
+            "code-insiders": "/usr/local/bin/code-insiders",
+            "windsurf": None,
+            "cursor": "/usr/local/bin/cursor",
+        },
+        existing_paths={bob_config, Path("/Applications/Claude.app"), windsurf_config},
+    )
+
+    detections = {detection.id: detection for detection in detect_clients(env)}
+
+    assert detections["ibm-bob"].detected is True
+    assert detections["codex"].command == "/usr/local/bin/codex"
+    assert detections["claude-code"].detected is False
+    assert detections["claude-desktop"].detected is True
+    assert detections["vscode"].command == "/usr/local/bin/code-insiders"
+    assert detections["windsurf"].detected is True
+    assert detections["cursor"].setup_method == "print_only"
+
+
+def test_select_clients_auto_all_and_requested(tmp_path: Path) -> None:
+    env = ClientEnvironment(
+        home=tmp_path,
+        commands={"codex": "/bin/codex"},
+        existing_paths=set(),
+    )
+    detections = detect_clients(env)
+
+    assert [detection.id for detection in select_clients("auto", detections)] == ["codex"]
+    assert [detection.id for detection in select_clients("codex,cursor", detections)] == ["codex", "cursor"]
+    assert len(select_clients("all", detections)) == 7
+    with pytest.raises(SystemExit):
+        select_clients("not-a-client", detections)
+
+
+def test_merge_json_config_preserves_existing_servers_and_creates_backup(tmp_path: Path) -> None:
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text(
+        json.dumps({"mcpServers": {"existing": {"command": "node"}}, "theme": "dark"}),
+        encoding="utf-8",
+    )
+
+    backup_path = merge_json_config(
+        config_path,
+        {"mcpServers": {"skillroute": {"command": "node", "args": ["mcp/build/index.js"]}}},
+    )
+
+    merged = json.loads(config_path.read_text(encoding="utf-8"))
+    assert backup_path is not None
+    assert backup_path.exists()
+    assert merged["mcpServers"]["existing"]["command"] == "node"
+    assert merged["mcpServers"]["skillroute"]["args"] == ["mcp/build/index.js"]
+    assert merged["theme"] == "dark"
+
+
+def test_apply_cursor_setup_prints_snippet_without_writing(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    cursor_config = tmp_path / "cursor" / "mcp.json"
+    detection = ClientDetection(
+        "cursor",
+        "Cursor",
+        True,
+        "found cursor",
+        "print_only",
+        command="/bin/cursor",
+        config_path=str(cursor_config),
+    )
+
+    result = apply_client_setup(
+        detection,
+        repo_root=repo_root,
+        catalog=tmp_path / "catalog.db",
+        mode="1",
+    )
+
+    assert result.status == "printed"
+    assert '"mcpServers"' in result.message
+    assert not cursor_config.exists()
+
+
+def test_apply_vscode_setup_uses_detected_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(command_parts: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append((command_parts, check))
+        return subprocess.CompletedProcess(command_parts, 0)
+
+    monkeypatch.setattr("skillroute.client_setup.subprocess.run", fake_run)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    detection = ClientDetection(
+        "vscode",
+        "VS Code",
+        True,
+        "found code-insiders",
+        "command",
+        command="/usr/local/bin/code-insiders",
+    )
+
+    result = apply_client_setup(
+        detection,
+        repo_root=repo_root,
+        catalog=tmp_path / "catalog.db",
+        mode="1",
+    )
+
+    assert result.status == "configured"
+    assert calls[0][0][0] == "/usr/local/bin/code-insiders"
+    assert calls[0][0][1] == "--add-mcp"
+    assert calls[0][1] is True
+
+
+def test_apply_missing_command_client_skips_without_running(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("subprocess.run should not be called for a missing command client")
+
+    monkeypatch.setattr("skillroute.client_setup.subprocess.run", fake_run)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    detection = ClientDetection(
+        "codex",
+        "Codex",
+        False,
+        "codex command not found",
+        "command",
+        command="codex",
+    )
+
+    result = apply_client_setup(
+        detection,
+        repo_root=repo_root,
+        catalog=tmp_path / "catalog.db",
+        mode="1",
+    )
+
+    assert result.status == "skipped"
+    assert result.message == "codex command not found"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -8,3 +8,19 @@ def test_shell_scripts_have_valid_bash_syntax() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     for script in ("scripts/bootstrap.sh", "scripts/install.sh"):
         subprocess.run(["bash", "-n", str(repo_root / script)], check=True)
+
+
+def test_install_script_help_is_skillroute_first() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    completed = subprocess.run(
+        [str(repo_root / "scripts" / "install.sh"), "--help"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "SkillRoute installer" in completed.stdout
+    assert "--clients SPEC" in completed.stdout
+    assert "--no-client-setup" in completed.stdout
+    assert "--no-bob-write" not in completed.stdout


### PR DESCRIPTION
## Summary
- make the curl installer SkillRoute-first instead of IBM Bob-branded
- add a Python client setup helper that detects IBM Bob, Codex, Claude Code, Claude Desktop, VS Code, Windsurf, and Cursor
- configure detected clients through the right setup path: JSON merge with backups, official CLI add commands, or Cursor print-only snippets
- extend `skillroute mcp config`, docs, and tests for VS Code, Windsurf, and Cursor

Follow-up to #3: IBM Bob remains first in the docs and supported clients, but it is no longer the installer identity.

## Verification
- `bash -n scripts/install.sh`
- `SKILLROUTE_CLIENT_SETUP=0 SKILLROUTE_INDEX_LOCAL_SKILLS=0 ./scripts/install.sh --yes`
- `uv run --extra dev ruff check .`
- `uv run --extra dev pytest`
- `npm --prefix mcp run build`
- `npm --prefix mcp run typecheck`
- `npm --prefix mcp run smoke`
- `uv run python -m skillroute.client_setup detect --json`
