### PR TITLE
feat: release readiness for v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,14 @@ jobs:
         working-directory: mcp
         run: npm run typecheck
 
+      - name: Test MCP server
+        working-directory: mcp
+        run: npm test
+
+      - name: Verify MCP package contents
+        working-directory: mcp
+        run: npm pack --dry-run
+
       - name: Audit MCP dependencies
         working-directory: mcp
         run: npm audit --audit-level=high
@@ -131,3 +139,34 @@ jobs:
       - name: Smoke test MCP tools
         working-directory: mcp
         run: npm run smoke
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          cache-suffix: package
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - name: Verify wheel bundles the web UI
+        run: unzip -l dist/*.whl | grep -q "skillroute/_web/index.html"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: Build sdist and wheel (bundles the web UI)
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - name: Verify wheel bundles the web UI
+        run: unzip -l dist/*.whl | grep -q "skillroute/_web/index.html"
+
+      - name: Pack MCP server tarball
+        working-directory: mcp
+        run: |
+          npm ci
+          npm pack --pack-destination ../dist
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-artifacts
+          path: dist/*
+
+  github-release:
+    name: Create GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: release-artifacts
+          path: dist
+
+      - name: Create release with artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes
+
+  pypi:
+    name: Publish to PyPI
+    if: vars.PYPI_PUBLISH == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: release-artifacts
+          path: dist
+
+      - name: Remove non-PyPI artifacts
+        run: rm -f dist/*.tgz
+
+      - name: Publish via trusted publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  npm:
+    name: Publish MCP server to npm
+    if: vars.NPM_PUBLISH == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish
+        working-directory: mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm ci
+          npm publish

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ mcp/node_modules/
 web/dist/
 web/node_modules/
 node_modules/
+
+dist/
+.mypy_cache/
+htmlcov/
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-08-10
+
+First release.
+
+### Added
+
+- SKILL.md bundle indexing into a local SQLite catalog (`skillroute index`)
+- Semantic routing with ranked skills, confidence, evidence snippets, suggested
+  order, and clarification questions (`skillroute route`)
+- Hybrid search over indexed skills (`skillroute search`) and per-skill
+  inspection (`skillroute inspect`)
+- Pluggable retrieval backends: local token backend and Astra Data API backend,
+  plus a LangChain retriever adapter
+- Metadata overlays for curating tags, domains, and languages without editing
+  skill sources
+- Route observability: persisted route traces (`skillroute traces list`)
+- Golden route evals (`skillroute eval run`)
+- Skill Atlas web UI (`skillroute ui`), bundled into the Python wheel
+- MCP stdio server (`@skillroute/mcp-server`) exposing `skillroute.route`,
+  `skillroute.search`, and `skillroute.inspect_skill`, with client setup via
+  `skillroute mcp config --client <client>`
+
+[0.1.0]: https://github.com/erichare/skill-route/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thanks for your interest in SkillRoute! This page covers local development and
+the release process.
+
+## Development setup
+
+Requirements: [uv](https://docs.astral.sh/uv/), Node 20+.
+
+```bash
+# Python package (src/skillroute) + tests
+uv sync --extra dev
+uv run --extra dev pytest --cov=skillroute --cov-fail-under=80
+uv run --extra dev ruff check .
+uv run --extra dev mypy
+
+# Skill Atlas web UI
+npm --prefix web ci
+npm --prefix web run typecheck && npm --prefix web run lint && npm --prefix web run test
+
+# MCP server
+npm --prefix mcp ci
+npm --prefix mcp run build && npm --prefix mcp test && npm --prefix mcp run smoke
+```
+
+CI mirrors these commands plus dependency audits and a packaging check; see
+[.github/workflows/ci.yml](.github/workflows/ci.yml).
+
+## Guidelines
+
+- Conventional commit messages (`feat:`, `fix:`, `chore:`, ...)
+- Add or update tests with behavior changes; overall coverage must stay >= 80%
+- `ruff` and `mypy` must pass
+
+## Releasing
+
+1. Bump the version in `pyproject.toml`, `mcp/package.json` (and
+   `web/package.json` for consistency). Python code and the MCP server read
+   their versions from package metadata — do not hardcode versions elsewhere.
+2. Add a section to `CHANGELOG.md` and update its compare/tag links.
+3. Land those changes on `main`, then tag and push:
+
+   ```bash
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+4. The [release workflow](.github/workflows/release.yml) builds the sdist,
+   wheel, and npm tarball, then creates a GitHub release with the artifacts
+   attached.
+   - PyPI publishing runs only when the `PYPI_PUBLISH` repository variable is
+     `true` and a [PyPI trusted publisher](https://docs.pypi.org/trusted-publishers/)
+     is configured for this repository.
+   - npm publishing runs only when the `NPM_PUBLISH` repository variable is
+     `true` and an `NPM_TOKEN` secret with publish rights to the
+     `@skillroute` scope is configured.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ and returns ranked skill plans with confidence, evidence, score breakdowns, and
 clarification prompts when the route is uncertain.
 
 ![CI](https://github.com/erichare/skill-route/actions/workflows/ci.yml/badge.svg)
+![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)
 
 ## Why
 
@@ -84,7 +86,7 @@ Trace inspection:
 - [Skill Atlas UI](docs/skill-atlas.md)
 - [MCP Server](docs/mcp-server.md)
 - [Golden Route Evals](docs/evals.md)
-- [Roadmap](docs/roadmap.md)
+- [Changelog](CHANGELOG.md)
 
 ## Core Commands
 
@@ -92,6 +94,7 @@ Trace inspection:
 uv run skillroute mcp config --client ibm-bob
 uv run skillroute mcp config --client codex
 uv run skillroute mcp config --client claude-code
+uv run skillroute mcp config --client claude-desktop
 uv run skillroute mcp config --client vscode
 uv run skillroute mcp config --client windsurf
 uv run skillroute mcp config --client cursor

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately via
+[GitHub security advisories](https://github.com/erichare/skill-route/security/advisories/new)
+rather than opening a public issue. You should receive a response within a week.
+
+## Scope notes
+
+- The Skill Atlas UI server (`skillroute ui`) binds to `127.0.0.1` by default
+  and is intended for local use; do not expose it to untrusted networks.
+- The MCP server executes the SkillRoute CLI locally and inherits the
+  permissions of the user running it.

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,39 @@
+"""Hatch build hook that ships the built web UI inside distributions.
+
+Wheels get the assets at ``skillroute/_web`` so ``skillroute ui`` works from a
+plain ``pip install``; sdists keep them at ``web/dist`` so wheels built from an
+sdist do not need node.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class WebAssetsBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        if version == "editable":
+            return
+        web_dir = Path(self.root) / "web"
+        dist = web_dir / "dist"
+        if not (dist / "index.html").exists():
+            self._build_web_assets(web_dir)
+        target = "skillroute/_web" if self.target_name == "wheel" else "web/dist"
+        build_data.setdefault("force_include", {})[str(dist)] = target
+
+    def _build_web_assets(self, web_dir: Path) -> None:
+        npm = shutil.which("npm")
+        if npm is None:
+            raise RuntimeError(
+                "web/dist is missing and npm is not available to build it. "
+                "Run `npm --prefix web ci && npm --prefix web run build` first."
+            )
+        subprocess.run([npm, "--prefix", str(web_dir), "ci"], check=True)
+        subprocess.run([npm, "--prefix", str(web_dir), "run", "build"], check=True)

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eric Hare
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,23 @@
+# SkillRoute MCP Server
+
+Stdio MCP server exposing [SkillRoute](https://github.com/erichare/skill-route) routing tools to agent clients: `skillroute.route`, `skillroute.search`, and `skillroute.inspect_skill`.
+
+The server bridges to the SkillRoute Python package, so install that first:
+
+```bash
+pip install skillroute
+```
+
+Then configure your MCP client to run:
+
+```bash
+npx @skillroute/mcp-server
+```
+
+In a SkillRoute source checkout the server autodetects the repo and runs against the checkout instead. Environment overrides:
+
+- `SKILLROUTE_REPO_ROOT` — force a specific checkout
+- `SKILLROUTE_PYTHON` — interpreter to run `-m skillroute` with
+- `SKILLROUTE_BRIDGE_TIMEOUT_MS` — bridge call timeout (default 30000)
+
+See the [main repository](https://github.com/erichare/skill-route) for full documentation, including `skillroute mcp config --client <client>` which generates client configuration for you.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@skillroute/mcp-server",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "zod": "^4.4.3"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,6 +2,24 @@
   "name": "@skillroute/mcp-server",
   "version": "0.1.0",
   "description": "SkillRoute MCP stdio server",
+  "license": "MIT",
+  "author": "Eric Hare",
+  "homepage": "https://github.com/erichare/skill-route#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/erichare/skill-route.git",
+    "directory": "mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/erichare/skill-route/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "agents",
+    "skills",
+    "routing"
+  ],
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -9,9 +27,17 @@
   "bin": {
     "skillroute-mcp": "build/index.js"
   },
+  "files": [
+    "build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
     "smoke": "node tests/mcp-smoke.mjs",
+    "test": "node --test 'tests/*.test.mjs'",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/mcp/src/bridge.ts
+++ b/mcp/src/bridge.ts
@@ -1,27 +1,78 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
-const repoRoot = process.env.SKILLROUTE_REPO_ROOT
-  ? path.resolve(process.env.SKILLROUTE_REPO_ROOT)
-  : path.resolve(currentDir, "../..");
-const pythonPath = process.env.SKILLROUTE_PYTHON ?? "python3";
-const timeoutMs = Number.parseInt(process.env.SKILLROUTE_BRIDGE_TIMEOUT_MS ?? "30000", 10);
 
 export type BridgeOperation = "route" | "search" | "inspect";
 
-export async function callBridge(operation: BridgeOperation, payload: unknown): Promise<unknown> {
-  const env = {
-    ...process.env,
-    PYTHONPATH: process.env.PYTHONPATH
-      ? `${path.join(repoRoot, "src")}${path.delimiter}${process.env.PYTHONPATH}`
-      : path.join(repoRoot, "src")
-  };
+export interface BridgeCommand {
+  command: string;
+  args: string[];
+  cwd: string | undefined;
+  env: NodeJS.ProcessEnv;
+}
 
-  const child = spawn(pythonPath, ["-m", "skillroute", "bridge", operation], {
-    cwd: repoRoot,
+/**
+ * Decide how to invoke the SkillRoute Python bridge.
+ *
+ * In a repo checkout (or with SKILLROUTE_REPO_ROOT set) the bridge runs
+ * `python -m skillroute` against the checkout's src tree. Outside a checkout
+ * (npx / global install) it runs the `skillroute` console script from a
+ * `pip install skillroute`, or `$SKILLROUTE_PYTHON -m skillroute` when set.
+ */
+export function resolveBridgeCommand(
+  operation: BridgeOperation,
+  options: { moduleDir?: string } = {}
+): BridgeCommand {
+  const bridgeArgs = ["bridge", operation];
+  const repoRoot = resolveRepoRoot(options.moduleDir ?? currentDir);
+  if (repoRoot) {
+    const srcPath = path.join(repoRoot, "src");
+    return {
+      command: process.env.SKILLROUTE_PYTHON ?? "python3",
+      args: ["-m", "skillroute", ...bridgeArgs],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PYTHONPATH: process.env.PYTHONPATH
+          ? `${srcPath}${path.delimiter}${process.env.PYTHONPATH}`
+          : srcPath
+      }
+    };
+  }
+  if (process.env.SKILLROUTE_PYTHON) {
+    return {
+      command: process.env.SKILLROUTE_PYTHON,
+      args: ["-m", "skillroute", ...bridgeArgs],
+      cwd: undefined,
+      env: { ...process.env }
+    };
+  }
+  return { command: "skillroute", args: bridgeArgs, cwd: undefined, env: { ...process.env } };
+}
+
+function resolveRepoRoot(moduleDir: string): string | undefined {
+  const override = process.env.SKILLROUTE_REPO_ROOT;
+  if (override) {
+    return path.resolve(override);
+  }
+  const candidate = path.resolve(moduleDir, "../..");
+  return existsSync(path.join(candidate, "src", "skillroute")) ? candidate : undefined;
+}
+
+function bridgeTimeoutMs(): number {
+  return Number.parseInt(process.env.SKILLROUTE_BRIDGE_TIMEOUT_MS ?? "30000", 10);
+}
+
+export async function callBridge(operation: BridgeOperation, payload: unknown): Promise<unknown> {
+  const { command, args, cwd, env } = resolveBridgeCommand(operation);
+  const timeoutMs = bridgeTimeoutMs();
+
+  const child = spawn(command, args, {
+    cwd,
     env,
     stdio: ["pipe", "pipe", "pipe"]
   });
@@ -53,7 +104,19 @@ export async function callBridge(operation: BridgeOperation, payload: unknown): 
 
   try {
     const exitCode = await new Promise<number | null>((resolve, reject) => {
-      child.on("error", reject);
+      child.on("error", (error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") {
+          reject(
+            new Error(
+              `SkillRoute bridge command not found: ${command}. Install the Python ` +
+                "package (`pip install skillroute`) or point SKILLROUTE_PYTHON or " +
+                "SKILLROUTE_REPO_ROOT at a working SkillRoute environment."
+            )
+          );
+          return;
+        }
+        reject(error);
+      });
       child.on("close", resolve);
     });
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
 import { callBridge } from "./bridge.js";
 
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
+
 const server = new McpServer({
   name: "skillroute",
-  version: "0.1.0"
+  version
 });
 
 const backendSchema = z

--- a/mcp/tests/bridge-command.test.mjs
+++ b/mcp/tests/bridge-command.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { resolveBridgeCommand } from "../build/bridge.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+// A directory tree with no src/skillroute, mimicking an npx/global install layout.
+const installedDir = path.join(mkdtempSync(path.join(os.tmpdir(), "skillroute-mcp-")), "build");
+
+const ENV_KEYS = ["SKILLROUTE_REPO_ROOT", "SKILLROUTE_PYTHON", "PYTHONPATH"];
+let savedEnv;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+test("checkout mode: runs python -m skillroute from the repo root with PYTHONPATH", () => {
+  // build/bridge.js sits inside the checkout, so autodetection finds src/skillroute.
+  const resolved = resolveBridgeCommand("route");
+  assert.equal(resolved.command, "python3");
+  assert.deepEqual(resolved.args, ["-m", "skillroute", "bridge", "route"]);
+  assert.equal(resolved.cwd, repoRoot);
+  assert.equal(resolved.env.PYTHONPATH, path.join(repoRoot, "src"));
+});
+
+test("checkout mode: SKILLROUTE_REPO_ROOT override and PYTHONPATH prepend", () => {
+  process.env.SKILLROUTE_REPO_ROOT = repoRoot;
+  process.env.PYTHONPATH = "/existing";
+  const resolved = resolveBridgeCommand("search", { moduleDir: installedDir });
+  assert.equal(resolved.cwd, repoRoot);
+  assert.equal(
+    resolved.env.PYTHONPATH,
+    `${path.join(repoRoot, "src")}${path.delimiter}/existing`
+  );
+});
+
+test("checkout mode: SKILLROUTE_PYTHON selects the interpreter", () => {
+  process.env.SKILLROUTE_PYTHON = "/opt/py/bin/python";
+  const resolved = resolveBridgeCommand("inspect");
+  assert.equal(resolved.command, "/opt/py/bin/python");
+  assert.deepEqual(resolved.args, ["-m", "skillroute", "bridge", "inspect"]);
+});
+
+test("installed mode: falls back to the skillroute console script", () => {
+  const resolved = resolveBridgeCommand("route", { moduleDir: installedDir });
+  assert.equal(resolved.command, "skillroute");
+  assert.deepEqual(resolved.args, ["bridge", "route"]);
+  assert.equal(resolved.cwd, undefined);
+  assert.equal(resolved.env.PYTHONPATH, undefined);
+});
+
+test("installed mode: SKILLROUTE_PYTHON forces python -m skillroute without PYTHONPATH", () => {
+  process.env.SKILLROUTE_PYTHON = "python3.13";
+  const resolved = resolveBridgeCommand("route", { moduleDir: installedDir });
+  assert.equal(resolved.command, "python3.13");
+  assert.deepEqual(resolved.args, ["-m", "skillroute", "bridge", "route"]);
+  assert.equal(resolved.env.PYTHONPATH, undefined);
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,16 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Eric Hare" }]
+keywords = ["agents", "skills", "routing", "mcp", "catalog"]
 classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
 ]
 dependencies = [
     "fastapi>=0.141.1",
@@ -25,12 +30,24 @@ dev = [
     "ruff>=0.16.1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/erichare/skill-route"
+Repository = "https://github.com/erichare/skill-route"
+Issues = "https://github.com/erichare/skill-route/issues"
+Changelog = "https://github.com/erichare/skill-route/blob/main/CHANGELOG.md"
+
 [project.scripts]
 skillroute = "skillroute.cli:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.targets.sdist.hooks.custom]
+path = "hatch_build.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/skillroute/__init__.py
+++ b/src/skillroute/__init__.py
@@ -1,10 +1,15 @@
 """SkillRoute core package."""
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
+
 from skillroute.catalog import Catalog, default_catalog_path
 from skillroute.models import SkillRecord
 from skillroute.routing import Router
 
 __all__ = ["Catalog", "Router", "SkillRecord", "default_catalog_path"]
 
-__version__ = "0.1.0"
-
+try:
+    __version__ = _package_version("skillroute")
+except PackageNotFoundError:  # pragma: no cover - only hit when run from an unbuilt tree
+    __version__ = "0.0.0.dev0"

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+import skillroute
 from skillroute.backends import (
     BACKEND_CHOICES,
     AstraDataAPIBackend,
@@ -48,6 +49,7 @@ def main(argv: list[str] | None = None) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="skillroute")
+    parser.add_argument("--version", action="version", version=f"skillroute {skillroute.__version__}")
     parser.add_argument("--catalog", type=Path, default=None, help="Path to the SQLite catalog")
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/src/skillroute/ui_server.py
+++ b/src/skillroute/ui_server.py
@@ -8,6 +8,7 @@ import webbrowser
 from pathlib import Path
 from typing import Any
 
+import skillroute
 from skillroute.atlas import (
     build_atlas_payload,
     catalog_summary,
@@ -41,7 +42,7 @@ class RoutePreviewRequest(BaseModel):
 def create_app(catalog_path: Path | str | None = None, web_dist: Path | None = None) -> FastAPI:
     catalog = Catalog(catalog_path or default_catalog_path())
     dist = web_dist or default_web_dist()
-    app = FastAPI(title="SkillRoute UI", version="0.1.0")
+    app = FastAPI(title="SkillRoute UI", version=skillroute.__version__)
 
     @app.get("/api/health")
     def health() -> dict[str, Any]:
@@ -114,7 +115,9 @@ def run_ui(
     dist = default_web_dist()
     if not (dist / "index.html").exists():
         raise SystemExit(
-            "SkillRoute UI build not found. Run `npm --prefix web install && npm --prefix web run build`."
+            "SkillRoute UI assets not found. In a source checkout run "
+            "`npm --prefix web ci && npm --prefix web run build`, or set "
+            "SKILLROUTE_WEB_DIST to a built UI directory."
         )
     app = create_app(catalog_path=catalog_path, web_dist=dist)
     if open_browser:
@@ -148,4 +151,19 @@ def default_web_dist() -> Path:
     override = os.environ.get("SKILLROUTE_WEB_DIST")
     if override:
         return Path(override).expanduser().resolve()
+    packaged = _packaged_web_dist()
+    if packaged is not None:
+        return packaged
+    return _repo_web_dist()
+
+
+def _packaged_web_dist() -> Path | None:
+    """Web assets bundled into the wheel by the hatch build hook (see hatch_build.py)."""
+    candidate = Path(__file__).resolve().parent / "_web"
+    if (candidate / "index.html").exists():
+        return candidate
+    return None
+
+
+def _repo_web_dist() -> Path:
     return Path(__file__).resolve().parents[2] / "web" / "dist"

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -122,4 +122,5 @@ def test_ui_command_reports_missing_web_build(tmp_path: Path, monkeypatch: pytes
     with pytest.raises(SystemExit) as exc_info:
         run_ui(catalog_path=tmp_path / "catalog.db", open_browser=False)
 
-    assert "npm --prefix web install && npm --prefix web run build" in str(exc_info.value)
+    assert "npm --prefix web ci && npm --prefix web run build" in str(exc_info.value)
+    assert "SKILLROUTE_WEB_DIST" in str(exc_info.value)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+import skillroute
+from skillroute import ui_server
 from skillroute.catalog import Catalog
 from skillroute.routing import Router
 from skillroute.ui_server import backend_from_name, create_app, default_web_dist
@@ -76,3 +78,36 @@ def test_backend_from_name_defaults_to_local() -> None:
 def test_default_web_dist_env_override(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("SKILLROUTE_WEB_DIST", str(tmp_path))
     assert default_web_dist() == tmp_path.resolve()
+
+
+def test_default_web_dist_prefers_packaged_assets(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("SKILLROUTE_WEB_DIST", raising=False)
+    packaged = tmp_path / "_web"
+    packaged.mkdir()
+    (packaged / "index.html").write_text("<!doctype html>", encoding="utf-8")
+    monkeypatch.setattr(ui_server, "_packaged_web_dist", lambda: packaged)
+    assert default_web_dist() == packaged
+
+
+def test_default_web_dist_env_override_beats_packaged(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SKILLROUTE_WEB_DIST", str(tmp_path / "override"))
+    monkeypatch.setattr(ui_server, "_packaged_web_dist", lambda: tmp_path / "_web")
+    assert default_web_dist() == (tmp_path / "override").resolve()
+
+
+def test_default_web_dist_falls_back_to_repo_checkout(monkeypatch) -> None:
+    monkeypatch.delenv("SKILLROUTE_WEB_DIST", raising=False)
+    monkeypatch.setattr(ui_server, "_packaged_web_dist", lambda: None)
+    dist = default_web_dist()
+    assert dist.parts[-2:] == ("web", "dist")
+
+
+def test_packaged_web_dist_absent_in_checkout() -> None:
+    assert ui_server._packaged_web_dist() is None
+
+
+def test_app_version_matches_package(indexed_catalog: Catalog, tmp_path: Path) -> None:
+    app = create_app(catalog_path=indexed_catalog.path, web_dist=tmp_path / "empty-dist")
+    assert app.version == skillroute.__version__
+    assert skillroute.__version__
+    assert skillroute.__version__ != "0.0.0.dev0"


### PR DESCRIPTION
## Summary

Implements the first-release plan: fixes both release blockers found in the repo sweep, single-sources versions, and adds release scaffolding and automation.

### Blocker 1 — web UI now ships in the wheel
- New hatch build hook ([hatch_build.py](https://github.com/erichare/skill-route/blob/chore/release-prep/hatch_build.py)) builds `web/dist` when missing and bundles it as `skillroute/_web` in wheels (`web/dist` in sdists, so building a wheel from the sdist needs no node)
- `default_web_dist()` resolves: `SKILLROUTE_WEB_DIST` → packaged assets → repo checkout
- **Verified end-to-end**: wheel installed into a clean venv resolves and serves the packaged UI

### Blocker 2 — MCP server is now publishable
- `npm pack` produces a working package (bin + build included, README/LICENSE bundled, prepack builds)
- Bridge autodetects a checkout; outside one it runs the installed `skillroute` console script or `$SKILLROUTE_PYTHON -m skillroute`, with a clear error otherwise
- New `node --test` suite covers command resolution in both modes

### Release scaffolding
- CHANGELOG.md (0.1.0), SECURITY.md, CONTRIBUTING.md incl. release process
- Tag-triggered release workflow: builds sdist/wheel/npm tarball + GitHub release with artifacts; PyPI (trusted publishing) and npm publish jobs are **off by default**, gated behind `PYPI_PUBLISH`/`NPM_PUBLISH` repo variables
- CI: new Package job (uv build, twine check, wheel-content assertion); MCP job runs node tests + `npm pack --dry-run`
- `__version__` from package metadata everywhere (was hardcoded in 6 places), `skillroute --version`
- README: badges, `claude-desktop` client documented, internal roadmap link removed

## Test plan
- [x] 131 Python tests pass, coverage 88% (gate 80%), ruff + mypy clean, golden routes pass
- [x] Wheel install verified in clean venv (`skillroute --version`, packaged UI assets resolve)
- [x] `npm pack --dry-run` shows correct tarball; mcp build/typecheck/test/smoke green
- [x] Both workflow YAMLs parse
- [ ] CI green on this PR

## After merging
1. Tag the release: `git tag v0.1.0 && git push origin v0.1.0` — this creates the GitHub release with artifacts.
2. Optional, to publish to PyPI: configure a [trusted publisher](https://docs.pypi.org/trusted-publishers/) for this repo + set repo variable `PYPI_PUBLISH=true` before tagging.
3. Optional, npm: the package is scoped `@skillroute/mcp-server` — you'd need to own the `skillroute` npm org (or rename the package), add `NPM_TOKEN`, and set `NPM_PUBLISH=true`.