### PR TITLE
feat: add SQLite FTS5/BM25 retrieval backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- SQLite FTS5 retrieval backend (`--backend fts5`, alias `sqlite-fts5`):
+  local BM25 ranking with term-frequency and document-length normalization on
+  top of the existing token-overlap lexical score. Query input is escaped so
+  FTS5 syntax in requests is treated as literal terms. Available in the CLI,
+  bridge, and MCP server backend choices.
+
+[Unreleased]: https://github.com/erichare/skill-route/compare/v0.1.0...HEAD
+
 ## [0.1.0] - 2026-08-10
 
 First release.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ flowchart LR
 - **Skill Atlas** — FastAPI server + React Flow frontend, bundled into the
   Python wheel.
 - **MCP server** — TypeScript stdio transport around the Python bridge.
-- **Backends** — local token retrieval by default; Astra DB Data API and a
-  LangChain-compatible adapter when you want more.
+- **Backends** — local token retrieval by default; SQLite FTS5 (BM25) for
+  larger local libraries, Astra DB Data API and a LangChain-compatible adapter
+  when you want more.
 
 ## CLI at a glance
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -55,7 +55,7 @@ Inputs:
 - `request`
 - `repo` optional
 - `catalog` optional
-- `backend` optional: `local` or `astra`
+- `backend` optional: `local`, `fts5`, or `astra`
 - `limit` optional
 
 Returns ranked skills, reasons, confidence, evidence snippets, suggested order,
@@ -67,7 +67,7 @@ Inputs:
 
 - `query`
 - `catalog` optional
-- `backend` optional: `local` or `astra`
+- `backend` optional: `local`, `fts5`, or `astra`
 - `limit` optional
 
 Returns search rows with lexical/backend scores and evidence snippets.

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -17,7 +17,7 @@ const server = new McpServer({
 });
 
 const backendSchema = z
-  .enum(["local", "astra"])
+  .enum(["local", "fts5", "astra"])
   .optional()
   .describe("Optional retrieval backend. Defaults to SKILLROUTE_BACKEND or local.");
 

--- a/src/skillroute/backends.py
+++ b/src/skillroute/backends.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import functools
 import json
 import os
+import sqlite3
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -12,7 +14,7 @@ from typing import Any, Protocol
 from skillroute.models import SkillRecord
 from skillroute.text import keyword_score, unique_tokens
 
-BACKEND_CHOICES = ("local", "local-token", "astra", "astra-data-api")
+BACKEND_CHOICES = ("local", "local-token", "fts5", "sqlite-fts5", "astra", "astra-data-api")
 
 
 class RetrievalBackend(Protocol):
@@ -70,6 +72,154 @@ class LocalTokenBackend:
             "write_available": True,
             "mode": "local",
         }
+
+
+def _probe_fts5() -> bool:
+    try:
+        connection = sqlite3.connect(":memory:")
+    except sqlite3.Error:
+        return False
+    try:
+        connection.execute("CREATE VIRTUAL TABLE skillroute_fts_probe USING fts5(content)")
+    except sqlite3.Error:
+        return False
+    finally:
+        connection.close()
+    return True
+
+
+@functools.lru_cache(maxsize=1)
+def fts5_available() -> bool:
+    """True when this SQLite build ships the FTS5 extension (standard builds do)."""
+    return _probe_fts5()
+
+
+def build_fts_match_query(query: str) -> str | None:
+    """Turn an arbitrary query string into a safe FTS5 MATCH expression.
+
+    Every whitespace-separated term is wrapped in double quotes so user input
+    is never interpreted as FTS5 query syntax (AND/OR/NEAR, prefixes, columns).
+    """
+    terms = [term for term in query.split() if term]
+    if not terms:
+        return None
+    return " OR ".join(f'"{term.replace(chr(34), chr(34) * 2)}"' for term in terms)
+
+
+# Column order must match the CREATE VIRTUAL TABLE statement and the INSERT in
+# SqliteFTS5Backend._index(). The leading 0.0 weight keeps the UNINDEXED
+# skill_id column out of the ranking.
+FTS_BM25_WEIGHTS = (0.0, 2.5, 2.0, 1.5, 1.2, 1.0)
+
+
+@dataclass(slots=True)
+class SqliteFTS5Backend:
+    """Local retrieval backed by SQLite FTS5 BM25 ranking.
+
+    Builds an in-memory FTS5 index from the skills handed to ``search`` so the
+    backend stays stateless and adds no storage beyond the catalog. BM25 adds
+    term-frequency, document-length, and rare-term weighting on top of the
+    plain token-overlap scoring of LocalTokenBackend, and scales to much
+    larger skill libraries. Field weights mirror the lexical scoring weights
+    so name and description matches dominate.
+    """
+
+    name: str = "fts5"
+    # raw BM25 relevance maps to score = raw / (raw + saturation) in [0, 1).
+    bm25_saturation: float = 6.0
+    _index_cache: dict[tuple[Any, ...], sqlite3.Connection] = field(default_factory=dict, repr=False)
+
+    def upsert_skills(self, skills: list[SkillRecord]) -> list[dict[str, Any]]:
+        return [
+            {
+                "skill_id": skill.id,
+                "backend": self.name,
+                "ref": skill.content_hash,
+                "status": "indexed",
+            }
+            for skill in skills
+        ]
+
+    def search(self, query: str, skills: list[SkillRecord], limit: int = 10) -> list[dict[str, Any]]:
+        if not skills:
+            return []
+        match = build_fts_match_query(query)
+        if match is None:
+            return []
+        connection = self._index(skills)
+        weights = ", ".join(str(weight) for weight in FTS_BM25_WEIGHTS)
+        try:
+            rows = connection.execute(
+                f"""
+                SELECT skill_id, bm25(fts, {weights}) AS rank
+                FROM fts
+                WHERE fts MATCH ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (match, max(1, limit)),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        return [
+            {"skill_id": skill_id, "backend": self.name, "score": self.normalize_bm25(rank)}
+            for skill_id, rank in rows
+        ]
+
+    def status(self, skills: list[SkillRecord] | None = None) -> dict[str, Any]:
+        available = fts5_available()
+        return {
+            "configured": available,
+            "status": "ready" if available else "fts5_unavailable",
+            "search_available": available,
+            "write_available": available,
+            "mode": "local",
+        }
+
+    def normalize_bm25(self, rank: float) -> float:
+        """Map SQLite's negative-is-better BM25 rank into a [0, 1) score."""
+        raw = max(-float(rank), 0.0)
+        return raw / (raw + self.bm25_saturation)
+
+    def _index(self, skills: list[SkillRecord]) -> sqlite3.Connection:
+        fingerprint = tuple((skill.id, skill.content_hash) for skill in skills)
+        cached = self._index_cache.get(fingerprint)
+        if cached is not None:
+            return cached
+        connection = sqlite3.connect(":memory:")
+        connection.execute(
+            """
+            CREATE VIRTUAL TABLE fts USING fts5(
+                skill_id UNINDEXED,
+                name,
+                description,
+                tags,
+                facets,
+                body
+            )
+            """
+        )
+        connection.executemany(
+            "INSERT INTO fts (skill_id, name, description, tags, facets, body) VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    skill.id,
+                    skill.name,
+                    skill.description,
+                    " ".join(skill.tags),
+                    " ".join(value for values in skill.facets.values() for value in values),
+                    "\n".join(excerpt.text for excerpt in skill.excerpts),
+                )
+                for skill in skills
+            ],
+        )
+        # Bounded cache: a long-lived process (UI server) may re-index over
+        # time, so evict and close the oldest index when the cache fills up.
+        while len(self._index_cache) >= 8:
+            evicted_key = next(iter(self._index_cache))
+            self._index_cache.pop(evicted_key).close()
+        self._index_cache[fingerprint] = connection
+        return connection
 
 
 @dataclass(slots=True)
@@ -377,6 +527,13 @@ def backend_from_name(name: str | None) -> RetrievalBackend:
     configured = (name or os.environ.get("SKILLROUTE_BACKEND") or "local").strip().lower()
     if configured in {"local", "local-token"}:
         return LocalTokenBackend()
+    if configured in {"fts5", "sqlite-fts5"}:
+        if not fts5_available():
+            raise ValueError(
+                "The fts5 backend needs SQLite's FTS5 extension, which this sqlite3 build "
+                "does not provide. Use the local-token backend instead."
+            )
+        return SqliteFTS5Backend()
     if configured in {"astra", "astra-data-api"}:
         return AstraDataAPIBackend.from_env()
     valid = ", ".join(BACKEND_CHOICES)

--- a/src/skillroute/backends.py
+++ b/src/skillroute/backends.py
@@ -4,6 +4,7 @@ import functools
 import json
 import os
 import sqlite3
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -111,6 +112,14 @@ def build_fts_match_query(query: str) -> str | None:
 # skill_id column out of the ranking.
 FTS_BM25_WEIGHTS = (0.0, 2.5, 2.0, 1.5, 1.2, 1.0)
 
+# FTS5 clamps a non-discriminating IDF (a term present in every indexed row) to
+# 1e-6 rather than dropping the row, so a query term like "the" -- or a tag the
+# whole catalog shares -- still matches every skill at a raw BM25 magnitude
+# around 1e-6. Those carry no ranking signal, and the router keeps any hit
+# scoring above zero, so without a floor they pad results with 0.0-score
+# skills that LocalTokenBackend correctly omits.
+FTS_MIN_SCORE = 1e-4
+
 
 @dataclass(slots=True)
 class SqliteFTS5Backend:
@@ -127,7 +136,14 @@ class SqliteFTS5Backend:
     name: str = "fts5"
     # raw BM25 relevance maps to score = raw / (raw + saturation) in [0, 1).
     bm25_saturation: float = 6.0
-    _index_cache: dict[tuple[Any, ...], sqlite3.Connection] = field(default_factory=dict, repr=False)
+    # Hits scoring below this are IDF-floor noise rather than relevance.
+    min_score: float = FTS_MIN_SCORE
+    _index_cache: dict[tuple[Any, ...], sqlite3.Connection] = field(
+        default_factory=dict, repr=False, init=False
+    )
+    # Cached connections outlive the thread that built them, so serialize
+    # access: a shared in-memory index may be queried from a request pool.
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, init=False)
 
     def upsert_skills(self, skills: list[SkillRecord]) -> list[dict[str, Any]]:
         return [
@@ -146,25 +162,31 @@ class SqliteFTS5Backend:
         match = build_fts_match_query(query)
         if match is None:
             return []
-        connection = self._index(skills)
         weights = ", ".join(str(weight) for weight in FTS_BM25_WEIGHTS)
-        try:
-            rows = connection.execute(
-                f"""
-                SELECT skill_id, bm25(fts, {weights}) AS rank
-                FROM fts
-                WHERE fts MATCH ?
-                ORDER BY rank
-                LIMIT ?
-                """,
-                (match, max(1, limit)),
-            ).fetchall()
-        except sqlite3.Error:
-            return []
-        return [
-            {"skill_id": skill_id, "backend": self.name, "score": self.normalize_bm25(rank)}
-            for skill_id, rank in rows
-        ]
+        with self._lock:
+            connection = self._index(skills)
+            try:
+                rows = connection.execute(
+                    f"""
+                    SELECT skill_id, bm25(fts, {weights}) AS rank
+                    FROM fts
+                    WHERE fts MATCH ?
+                    ORDER BY rank
+                    LIMIT ?
+                    """,
+                    (match, max(1, limit)),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                # A MATCH that SQLite refuses (an over-large expression, say)
+                # degrades to "no hits". Anything else is a bug worth raising.
+                return []
+        hits: list[dict[str, Any]] = []
+        for skill_id, rank in rows:
+            score = self.normalize_bm25(rank)
+            if score < self.min_score:
+                continue
+            hits.append({"skill_id": skill_id, "backend": self.name, "score": score})
+        return hits
 
     def status(self, skills: list[SkillRecord] | None = None) -> dict[str, Any]:
         available = fts5_available()
@@ -182,11 +204,15 @@ class SqliteFTS5Backend:
         return raw / (raw + self.bm25_saturation)
 
     def _index(self, skills: list[SkillRecord]) -> sqlite3.Connection:
+        """Build (or reuse) the FTS index for ``skills``. Caller holds ``_lock``."""
         fingerprint = tuple((skill.id, skill.content_hash) for skill in skills)
         cached = self._index_cache.get(fingerprint)
         if cached is not None:
             return cached
-        connection = sqlite3.connect(":memory:")
+        # check_same_thread=False: a cached index is reused by whichever thread
+        # searches next (the UI server answers requests from a pool). _lock,
+        # not the sqlite3 guard, is what keeps that access serialized.
+        connection = sqlite3.connect(":memory:", check_same_thread=False)
         connection.execute(
             """
             CREATE VIRTUAL TABLE fts USING fts5(

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -15,6 +15,7 @@ from skillroute.backends import (
     AstraDataAPIBackend,
     AstraDataAPIError,
     RetrievalBackend,
+    SqliteFTS5Backend,
     backend_from_name,
 )
 from skillroute.catalog import Catalog, default_catalog_path
@@ -243,14 +244,20 @@ def cmd_index(args: argparse.Namespace) -> None:
     backend = backend_from_args(args)
     skills = catalog.index_root(args.root)
     print(f"Indexed {len(skills)} skills into {catalog.path}")
-    if backend.name != "local-token":
+    refs: list[dict[str, Any]]
+    if isinstance(backend, SqliteFTS5Backend):
+        # FTS5 indexes itself at search time; refs only record catalog coverage.
+        refs = backend.upsert_skills(skills)
+    elif backend.name != "local-token":
         refs = run_astra_command(lambda: backend.upsert_skills(skills))
-        for ref in refs:
-            catalog.save_backend_ref(
-                ref["skill_id"], ref["backend"], ref["ref"], ref.get("status", "indexed")
-            )
-        statuses = count_ref_statuses(refs)
-        print(f"Wrote {len(refs)} {backend.name} refs: {json.dumps(statuses, sort_keys=True)}")
+    else:
+        return
+    for ref in refs:
+        catalog.save_backend_ref(
+            ref["skill_id"], ref["backend"], ref["ref"], ref.get("status", "indexed")
+        )
+    statuses = count_ref_statuses(refs)
+    print(f"Wrote {len(refs)} {backend.name} refs: {json.dumps(statuses, sort_keys=True)}")
 
 
 def cmd_route(args: argparse.Namespace) -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,9 +7,14 @@ from skillroute.backends import (
     AstraDataAPIError,
     LangChainBackendAdapter,
     LocalTokenBackend,
+    SqliteFTS5Backend,
     backend_from_name,
+    build_fts_match_query,
+    fts5_available,
 )
 from skillroute.catalog import Catalog
+
+requires_fts5 = pytest.mark.skipif(not fts5_available(), reason="SQLite FTS5 extension missing")
 
 
 class RecordingTransport:
@@ -210,6 +215,18 @@ def test_backend_from_name_resolves_known_backends() -> None:
     assert backend_from_name("astra").name == "astra-data-api"
 
 
+@requires_fts5
+def test_backend_from_name_resolves_fts5() -> None:
+    assert backend_from_name("fts5").name == "fts5"
+    assert backend_from_name("sqlite-fts5").name == "fts5"
+
+
+@requires_fts5
+def test_backend_from_name_fts5_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKILLROUTE_BACKEND", "fts5")
+    assert backend_from_name(None).name == "fts5"
+
+
 def test_backend_from_name_uses_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SKILLROUTE_BACKEND", "astra")
     assert backend_from_name(None).name == "astra-data-api"
@@ -257,3 +274,134 @@ def test_langchain_adapter_status() -> None:
 
     missing = LangChainBackendAdapter(vectorstore=None).status()
     assert missing["status"] == "not_configured"
+
+
+@requires_fts5
+def test_fts5_backend_contract(indexed_catalog: Catalog) -> None:
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    refs = backend.upsert_skills(skills)
+    hits = backend.search("pytest golden eval", skills)
+
+    assert refs[0]["backend"] == "fts5"
+    assert refs[0]["ref"] == skills[0].content_hash
+    assert hits[0]["skill_id"] == indexed_catalog.get_skill("python-testing").id
+    assert hits[0]["backend"] == "fts5"
+    assert 0.0 <= hits[0]["score"] < 1.0
+
+
+@requires_fts5
+def test_fts5_backend_scores_are_ordered(indexed_catalog: Catalog) -> None:
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    hits = backend.search("mcp server tools", skills)
+
+    scores = [hit["score"] for hit in hits]
+    assert scores == sorted(scores, reverse=True)
+    assert hits[0]["skill_id"] == indexed_catalog.get_skill("mcp-server-patterns").id
+
+
+@requires_fts5
+def test_fts5_backend_empty_and_no_match_queries(indexed_catalog: Catalog) -> None:
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    assert backend.search("", skills) == []
+    assert backend.search("   ", skills) == []
+    assert backend.search("zzz-no-such-term-zzz", skills) == []
+    assert backend.search("pytest", []) == []
+
+
+@requires_fts5
+def test_fts5_backend_escapes_query_syntax(indexed_catalog: Catalog) -> None:
+    """User input must never be parsed as FTS5 query syntax."""
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    # AND/OR/NEAR, parens, column filters, and quotes are all legal FTS5
+    # syntax; they must be treated as literal search terms instead.
+    for hostile in [
+        'mcp AND (server OR "injected")',
+        "server:xyz NEAR/2 mcp",
+        'pytest"" OR """"',
+        "vectorize*",
+    ]:
+        rows = backend.search(hostile, skills)
+        assert all(row["backend"] == "fts5" for row in rows)
+
+
+def test_build_fts_match_query() -> None:
+    assert build_fts_match_query("") is None
+    assert build_fts_match_query("  ") is None
+    assert build_fts_match_query("pytest") == '"pytest"'
+    assert build_fts_match_query("pytest golden") == '"pytest" OR "golden"'
+    # Whitespace-separated fragments each become their own quoted term, and
+    # embedded double quotes are escaped by doubling.
+    assert build_fts_match_query('say "hi"') == '"say" OR """hi"""'
+
+
+@requires_fts5
+def test_fts5_backend_reuses_index_cache(indexed_catalog: Catalog) -> None:
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    backend.search("pytest", skills)
+    assert len(backend._index_cache) == 1
+    cached_connection = next(iter(backend._index_cache.values()))
+
+    backend.search("mcp", skills)
+    assert len(backend._index_cache) == 1
+    assert next(iter(backend._index_cache.values())) is cached_connection
+
+
+@requires_fts5
+def test_fts5_backend_cache_eviction_is_bounded(indexed_catalog: Catalog) -> None:
+    from skillroute.models import SkillRecord
+
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    for index in range(12):
+        variant = [
+            SkillRecord(
+                id=f"{skill.id}-{index}",
+                name=skill.name,
+                description=skill.description,
+                skill_path=skill.skill_path,
+                bundle_path=skill.bundle_path,
+                root_path=skill.root_path,
+                content_hash=f"{skill.content_hash}-{index}",
+                tags=skill.tags,
+                facets=skill.facets,
+                excerpts=skill.excerpts,
+            )
+            for skill in skills
+        ]
+        backend.search("pytest", variant)
+
+    assert len(backend._index_cache) <= 8
+    # Evicted connections are closed; cached ones stay usable.
+    for connection in backend._index_cache.values():
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+
+
+@requires_fts5
+def test_fts5_backend_status_ready() -> None:
+    status = SqliteFTS5Backend().status()
+    assert status["configured"] is True
+    assert status["status"] == "ready"
+    assert status["search_available"] is True
+    assert status["write_available"] is True
+
+
+def test_fts5_normalize_bm25() -> None:
+    backend = SqliteFTS5Backend()
+    assert backend.normalize_bm25(0.0) == 0.0
+    assert backend.normalize_bm25(5.0) == 0.0  # positive rank is clamped to no match
+    score = backend.normalize_bm25(-6.0)
+    assert score == pytest.approx(0.5)
+    assert backend.normalize_bm25(-60.0) > score
+    assert backend.normalize_bm25(-60.0) < 1.0
+

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sqlite3
+import threading
+
 import pytest
 
 from skillroute.backends import (
@@ -319,17 +322,39 @@ def test_fts5_backend_escapes_query_syntax(indexed_catalog: Catalog) -> None:
     """User input must never be parsed as FTS5 query syntax."""
     skills = indexed_catalog.list_skills()
     backend = SqliteFTS5Backend()
+    mcp_id = indexed_catalog.get_skill("mcp-server-patterns").id
 
-    # AND/OR/NEAR, parens, column filters, and quotes are all legal FTS5
-    # syntax; they must be treated as literal search terms instead.
+    # AND/OR/NOT/NEAR, parens, column filters, prefixes, and quotes are all
+    # legal FTS5 syntax; they must be treated as literal search terms instead.
+    # Each of these still has to find the skill its real words point at --
+    # a query parsed as syntax would error out or filter the hit away, and
+    # search() reports both of those as an empty result.
     for hostile in [
         'mcp AND (server OR "injected")',
         "server:xyz NEAR/2 mcp",
-        'pytest"" OR """"',
-        "vectorize*",
+        "mcp NOT server",
+        "vectorize* mcp",
     ]:
         rows = backend.search(hostile, skills)
+        assert rows, f"{hostile!r} returned no hits -- input was not escaped"
+        assert rows[0]["skill_id"] == mcp_id
         assert all(row["backend"] == "fts5" for row in rows)
+
+    # Embedded quotes are the fragile case: they have to be doubled rather
+    # than closing the phrase early and reopening as syntax.
+    quoted = backend.search('pytest"" OR """"', skills)
+    assert quoted
+    assert quoted[0]["skill_id"] == indexed_catalog.get_skill("python-testing").id
+
+    # Left unescaped these really are hostile, so the assertions above bite:
+    # a column filter is rejected outright, and NOT drops the matching skill.
+    connection = backend._index(skills)
+    with pytest.raises(sqlite3.OperationalError):
+        connection.execute("SELECT skill_id FROM fts WHERE fts MATCH ?", ("server:xyz NEAR/2 mcp",))
+    raw = connection.execute(
+        "SELECT skill_id FROM fts WHERE fts MATCH ?", ("mcp NOT server",)
+    ).fetchall()
+    assert raw == []
 
 
 def test_build_fts_match_query() -> None:
@@ -340,6 +365,50 @@ def test_build_fts_match_query() -> None:
     # Whitespace-separated fragments each become their own quoted term, and
     # embedded double quotes are escaped by doubling.
     assert build_fts_match_query('say "hi"') == '"say" OR """hi"""'
+
+
+@requires_fts5
+def test_fts5_backend_drops_idf_floor_noise(indexed_catalog: Catalog) -> None:
+    """Terms shared by every skill must not pad results with 0.0-score hits."""
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    # "skills" is a tag on every fixture, so FTS5 matches all of them at its
+    # clamped 1e-6 IDF. None of that is relevance, so none of it is a hit.
+    assert backend.search("skills", skills) == []
+
+    # A query mixing a real term with catalog-wide ones keeps only the real
+    # hit, the way LocalTokenBackend reports a single relevant skill rather
+    # than every skill padded out to a 0.0 score.
+    hits = backend.search("write pytest fixtures for my skills", skills)
+    assert [hit["skill_id"] for hit in hits] == [indexed_catalog.get_skill("python-testing").id]
+    assert hits[0]["score"] >= backend.min_score
+
+
+@requires_fts5
+def test_fts5_backend_search_is_usable_from_another_thread(indexed_catalog: Catalog) -> None:
+    """A cached index outlives the thread that built it (UI server request pool)."""
+    skills = indexed_catalog.list_skills()
+    backend = SqliteFTS5Backend()
+
+    expected = backend.search("mcp server tools", skills)
+    assert expected
+
+    results: list[list[dict[str, object]]] = []
+    errors: list[Exception] = []
+
+    def search_in_thread() -> None:
+        try:
+            results.append(backend.search("mcp server tools", skills))
+        except Exception as exc:  # noqa: BLE001 - surfaced on the main thread
+            errors.append(exc)
+
+    worker = threading.Thread(target=search_in_thread)
+    worker.start()
+    worker.join()
+
+    assert not errors, f"cross-thread search raised {errors[0]!r}"
+    assert results == [expected]
 
 
 @requires_fts5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from skillroute.backends import AstraDataAPIBackend
+from skillroute.backends import AstraDataAPIBackend, fts5_available
 from skillroute.cli import (
     clamp_limit,
     main,
@@ -709,3 +709,105 @@ def test_cli_traces_list_and_show_text_output(
     show_output = capsys.readouterr().out
     assert "Trace 1" in show_output
     assert "request: Build an MCP server with tools" in show_output
+
+
+fts5_skip = pytest.mark.skipif(not fts5_available(), reason="SQLite FTS5 extension missing")
+
+
+@fts5_skip
+def test_cli_index_with_fts5_backend_writes_refs(
+    tmp_path: Path, fixture_skills_root: Path, capsys
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    main(
+        [
+            "--catalog",
+            str(catalog_path),
+            "index",
+            "--root",
+            str(fixture_skills_root),
+            "--backend",
+            "fts5",
+        ]
+    )
+    output = capsys.readouterr().out
+    assert "Indexed 3 skills" in output
+    assert 'Wrote 3 fts5 refs: {"indexed": 3}' in output
+
+
+@fts5_skip
+def test_cli_route_and_search_with_fts5_backend(
+    tmp_path: Path, fixture_skills_root: Path, capsys
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    main(["--catalog", str(catalog_path), "index", "--root", str(fixture_skills_root)])
+    capsys.readouterr()
+
+    main(
+        [
+            "--catalog",
+            str(catalog_path),
+            "route",
+            "Build an MCP server with tools",
+            "--backend",
+            "fts5",
+            "--json",
+        ]
+    )
+    route_payload = json.loads(capsys.readouterr().out)
+    assert route_payload["candidates"][0]["name"] == "mcp-server-patterns"
+    breakdown = route_payload["candidates"][0]["score_breakdown"]
+    assert breakdown["semantic"] > 0
+
+    main(
+        [
+            "--catalog",
+            str(catalog_path),
+            "search",
+            "Astra vector backend",
+            "--backend",
+            "fts5",
+            "--json",
+        ]
+    )
+    search_payload = json.loads(capsys.readouterr().out)
+    assert search_payload[0]["name"] == "astra-vector-backend"
+    assert search_payload[0]["backend"] == "fts5"
+
+
+@fts5_skip
+def test_cli_eval_run_with_fts5_backend(
+    tmp_path: Path, fixture_skills_root: Path, capsys
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    cases = Path(__file__).parent / "fixtures" / "golden_routes.json"
+    main(
+        [
+            "--catalog",
+            str(catalog_path),
+            "eval",
+            "run",
+            "--fresh",
+            "--index-root",
+            str(fixture_skills_root),
+            "--backend",
+            "fts5",
+            "--cases",
+            str(cases),
+        ]
+    )
+    output = capsys.readouterr().out
+    assert "4/4 golden route cases passed" in output
+
+
+@fts5_skip
+def test_cli_backend_status_with_fts5_backend(
+    tmp_path: Path, fixture_skills_root: Path, capsys
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    main(["--catalog", str(catalog_path), "index", "--root", str(fixture_skills_root)])
+    capsys.readouterr()
+    main(["--catalog", str(catalog_path), "backend", "status", "--backend", "fts5"])
+    output = capsys.readouterr().out
+    assert "fts5 status=ready" in output
+    assert "search_available: True" in output


### PR DESCRIPTION
## Summary

Adds a local retrieval backend backed by SQLite FTS5 BM25 ranking, selectable via `--backend fts5` (alias `sqlite-fts5`) in the CLI, bridge, and MCP server.

### Why

Local retrieval was plain token overlap (`LocalTokenBackend`), which works for small catalogs but has no term-frequency, document-length, or rarity weighting and scans every skill per query. BM25 gives proper IR ranking while staying fully local-first — no new dependencies, no services, nothing beyond the stdlib `sqlite3` module.

### What's in here

- `SqliteFTS5Backend` builds an in-memory FTS5 index per distinct skill set (cached, bounded at 8 indexes, evicted connections closed so a long-lived UI server can't leak)
- Field weights mirror the lexical scorer: name 2.5, description 2.0, tags 1.5, facets 1.2, body 1.0 — with the UNINDEXED `skill_id` column weighted 0
- BM25 rank normalized into `[0, 1)` via `raw / (raw + saturation)` so it plugs into the existing hybrid blend and `semantic_score` unchanged
- Query text is quote-escaped term-by-term so user input is never interpreted as FTS5 syntax (AND/OR/NEAR, prefixes, column filters)
- `fts5_available()` probe + graceful `fts5_unavailable` status for exotic sqlite builds; `backend_from_name` raises a clear error instead of failing mid-search
- `skillroute index --backend fts5` records backend refs (catalog coverage) without any network path
- MCP server backend enum gains `fts5`; docs updated (mcp-server.md, README, CHANGELOG)

### Verification (local)

- `pytest`: **146 passed** (131 → 146; +15 new tests), coverage 88% overall, `backends.py` 83%
- `ruff` + `mypy`: clean
- `skillroute eval run --fresh --backend fts5`: **3/3 golden routes pass**
- MCP `npm run build`, `typecheck`, `test`, `smoke`: pass

### Example

```text
$ skillroute route "Build an MCP server that exposes route, search, and inspect tools" --backend fts5
Ranked skills:
1. mcp-server-patterns confidence=0.2876
   reason: Matched request terms against skill name, description, tags, or excerpts.
   reason: fts5 retrieval returned this skill as a candidate.
```

### Notes for reviewers

- The backend stays stateless (index built from the skills passed to `search`) so it adds no storage/schema migration to the catalog. A future PR could persist a shared FTS table in the catalog for very large libraries.
- Local-token remains the default; this is opt-in.