### PR TITLE
feat: make routing weights explicit and eval-tunable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Routing weights are now explicit and tunable: `RouteWeights` replaces the
+  hardcoded blend constants, `SKILLROUTE_WEIGHTS` overrides them per process,
+  and `skillroute eval tune` grid-searches weights against golden route cases
+  so changes are backed by eval evidence. Defaults are unchanged.
+
+[Unreleased]: https://github.com/erichare/skill-route/compare/v0.1.0...HEAD
+
 ## [0.1.0] - 2026-08-10
 
 First release.

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -49,3 +49,35 @@ Add a case when:
 - a new skill domain is introduced
 - scoring weights change
 - a backend adapter starts influencing candidate retrieval
+
+## Tuning Routing Weights
+
+The hybrid route blend (lexical, semantic, repo context, graph) and the
+clarification thresholds are weights, not magic numbers. Tune them against
+your eval cases:
+
+```bash
+uv run skillroute eval tune \
+  --fresh \
+  --index-root examples/skills \
+  --cases examples/evals/golden_routes.json \
+  --top 5
+```
+
+The tuner grid-searches blend weights on the unit simplex (step size via
+`--step`) together with confidence-floor and clarification-gap thresholds,
+scoring each set by `passed/total + mean reciprocal rank + 0.25 *
+clarification accuracy`. The built-in defaults are always evaluated first and
+win ties, so tuning only changes behavior when the evidence supports it.
+
+Apply a winning weight set with the `SKILLROUTE_WEIGHTS` environment variable
+(the tuner prints the exact value):
+
+```bash
+SKILLROUTE_WEIGHTS='{"lexical": 0.6, "semantic": 0.2, "repo_context": 0.1, "graph": 0.1}' \
+  uv run skillroute route "Build an MCP server"
+```
+
+Valid keys: `lexical`, `semantic`, `repo_context`, `graph`,
+`confidence_floor`, `clarification_gap`. Unknown keys or negative values are
+rejected.

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -120,7 +120,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--step",
         type=float,
         default=0.2,
-        help="Blend weight grid step in (0, 1]. Smaller explores more combinations.",
+        help=(
+            "Blend weight grid step in (0, 1]. Smaller explores more combinations. "
+            "Snapped to the nearest 1/N so blends stay on the unit simplex."
+        ),
     )
     eval_tune_parser.add_argument(
         "--top",
@@ -272,6 +275,14 @@ def backend_from_args(args: argparse.Namespace) -> RetrievalBackend:
         raise SystemExit(str(exc)) from exc
 
 
+def router_from_args(catalog: Catalog, args: argparse.Namespace) -> Router:
+    """Build a Router, reporting a bad SKILLROUTE_WEIGHTS the way bad flags are."""
+    try:
+        return Router(catalog, backend=backend_from_args(args))
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+
 def cmd_index(args: argparse.Namespace) -> None:
     catalog = catalog_from_args(args)
     backend = backend_from_args(args)
@@ -295,7 +306,7 @@ def cmd_index(args: argparse.Namespace) -> None:
 
 def cmd_route(args: argparse.Namespace) -> None:
     catalog = catalog_from_args(args)
-    response = Router(catalog, backend=backend_from_args(args)).route(args.request, repo=args.repo, limit=args.limit)
+    response = router_from_args(catalog, args).route(args.request, repo=args.repo, limit=args.limit)
     if args.as_json:
         print_json(response)
         return
@@ -304,7 +315,7 @@ def cmd_route(args: argparse.Namespace) -> None:
 
 def cmd_search(args: argparse.Namespace) -> None:
     catalog = catalog_from_args(args)
-    rows = Router(catalog, backend=backend_from_args(args)).search(args.query, limit=args.limit)
+    rows = router_from_args(catalog, args).search(args.query, limit=args.limit)
     if args.as_json:
         print_json(rows)
         return
@@ -352,7 +363,7 @@ def cmd_eval_run(args: argparse.Namespace) -> None:
         for root in args.index_root:
             catalog.index_root(root)
         try:
-            results = run_golden_routes(Router(catalog, backend=backend_from_args(args)), args.cases)
+            results = run_golden_routes(router_from_args(catalog, args), args.cases)
         except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
             raise SystemExit(f"Could not run eval cases from {args.cases}: {exc}") from exc
     if args.as_json:

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -33,6 +33,7 @@ from skillroute.metadata import (
 )
 from skillroute.models import to_jsonable
 from skillroute.routing import Router
+from skillroute.tuning import tune_weights
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -97,6 +98,38 @@ def build_parser() -> argparse.ArgumentParser:
     add_backend_argument(eval_run_parser)
     eval_run_parser.add_argument("--json", action="store_true", dest="as_json")
     eval_run_parser.set_defaults(func=cmd_eval_run)
+    eval_tune_parser = eval_subparsers.add_parser(
+        "tune",
+        help="Grid-search routing weights against golden route cases",
+    )
+    eval_tune_parser.add_argument("--cases", type=Path, required=True)
+    eval_tune_parser.add_argument(
+        "--index-root",
+        type=Path,
+        action="append",
+        default=[],
+        help="Index a skill root before tuning. Can be passed multiple times.",
+    )
+    eval_tune_parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="Tune against a temporary isolated catalog.",
+    )
+    eval_tune_parser.add_argument(
+        "--step",
+        type=float,
+        default=0.2,
+        help="Blend weight grid step in (0, 1]. Smaller explores more combinations.",
+    )
+    eval_tune_parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="How many best weight sets to print.",
+    )
+    add_backend_argument(eval_tune_parser)
+    eval_tune_parser.add_argument("--json", action="store_true", dest="as_json")
+    eval_tune_parser.set_defaults(func=cmd_eval_tune)
 
     dogfood_parser = subparsers.add_parser("dogfood", help="Dogfood SkillRoute against local skill roots")
     dogfood_subparsers = dogfood_parser.add_subparsers(dest="dogfood_command", required=True)
@@ -327,6 +360,37 @@ def cmd_eval_run(args: argparse.Namespace) -> None:
             print(f"  {note}")
     if passed != len(results):
         raise SystemExit(1)
+
+
+def cmd_eval_tune(args: argparse.Namespace) -> None:
+    context = TemporaryDirectory() if args.fresh else nullcontext(None)
+    with context as temp_dir:
+        catalog = Catalog(Path(temp_dir) / "catalog.db") if temp_dir else catalog_from_args(args)
+        for root in args.index_root:
+            catalog.index_root(root)
+        try:
+            results = tune_weights(
+                catalog,
+                args.cases,
+                backend=backend_from_args(args),
+                step=args.step,
+            )
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            raise SystemExit(f"Could not tune weights from {args.cases}: {exc}") from exc
+    top = max(1, args.top)
+    if args.as_json:
+        print_json([result.to_json() for result in results[:top]])
+        return
+    if not results:
+        print("No eval cases to tune against.")
+        return
+    print(f"Top {min(top, len(results))} weight sets ({results[0].total} cases):")
+    for rank, result in enumerate(results[:top], start=1):
+        print(f"{rank}. score={result.score:.4f} passed={result.passed}/{result.total}")
+        print(f"   mrr={result.mean_reciprocal_rank:.4f} clarification={result.clarification_accuracy:.4f}")
+        print(f"   weights: {json.dumps(result.weights, sort_keys=True)}")
+    best = results[0]
+    print("\nApply with: SKILLROUTE_WEIGHTS='" + json.dumps(best.weights, sort_keys=True) + "'")
 
 
 def cmd_dogfood_roots(args: argparse.Namespace) -> None:

--- a/src/skillroute/routing.py
+++ b/src/skillroute/routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
@@ -56,6 +57,10 @@ class RouteWeights:
                 value = float(raw)  # type: ignore[arg-type]
             except (TypeError, ValueError) as exc:
                 raise ValueError(f"Route weight {name} must be a number, got {raw!r}") from exc
+            # inf/NaN slip past the >= 0 check (NaN compares false against
+            # everything) and would poison every total and confidence.
+            if not math.isfinite(value):
+                raise ValueError(f"Route weight {name} must be finite, got {value}")
             if value < 0:
                 raise ValueError(f"Route weight {name} must be >= 0, got {value}")
             values[name] = value

--- a/src/skillroute/routing.py
+++ b/src/skillroute/routing.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +14,69 @@ from skillroute.models import RouteCandidate, RouteResponse, ScoreBreakdown, Ski
 from skillroute.rerankers import Reranker, default_reranker
 from skillroute.text import best_snippets, keyword_score, unique_tokens
 
+DEFAULT_WEIGHTS = {
+    "lexical": 0.5,
+    "semantic": 0.25,
+    "repo_context": 0.15,
+    "graph": 0.10,
+    "confidence_floor": 0.18,
+    "clarification_gap": 0.025,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RouteWeights:
+    """Blend weights and clarification thresholds for hybrid routing.
+
+    Defaults match the historical hardcoded behavior. Override per-process with
+    the SKILLROUTE_WEIGHTS environment variable (a JSON object whose keys are a
+    subset of the field names), or pass an instance to ``Router`` directly.
+    """
+
+    lexical: float = DEFAULT_WEIGHTS["lexical"]
+    semantic: float = DEFAULT_WEIGHTS["semantic"]
+    repo_context: float = DEFAULT_WEIGHTS["repo_context"]
+    graph: float = DEFAULT_WEIGHTS["graph"]
+    confidence_floor: float = DEFAULT_WEIGHTS["confidence_floor"]
+    clarification_gap: float = DEFAULT_WEIGHTS["clarification_gap"]
+
+    @classmethod
+    def from_overrides(cls, overrides: Mapping[str, Any]) -> RouteWeights:
+        field_names = {field.name for field in fields(cls)}
+        unknown = sorted(set(overrides) - field_names)
+        if unknown:
+            raise ValueError(
+                f"Unknown route weight keys: {', '.join(unknown)}. "
+                f"Valid keys: {', '.join(sorted(field_names))}"
+            )
+        values: dict[str, float] = {}
+        for name in field_names:
+            raw = overrides.get(name, DEFAULT_WEIGHTS[name])
+            try:
+                value = float(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Route weight {name} must be a number, got {raw!r}") from exc
+            if value < 0:
+                raise ValueError(f"Route weight {name} must be >= 0, got {value}")
+            values[name] = value
+        return cls(**values)
+
+    @classmethod
+    def from_env(cls) -> RouteWeights:
+        raw = os.environ.get("SKILLROUTE_WEIGHTS")
+        if not raw:
+            return cls()
+        try:
+            overrides = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"SKILLROUTE_WEIGHTS is not valid JSON: {exc}") from exc
+        if not isinstance(overrides, dict):
+            raise TypeError("SKILLROUTE_WEIGHTS must be a JSON object")
+        return cls.from_overrides(overrides)
+
+    def to_json(self) -> dict[str, float]:
+        return {field.name: getattr(self, field.name) for field in fields(self)}
+
 
 class Router:
     def __init__(
@@ -17,10 +84,12 @@ class Router:
         catalog: Catalog,
         backend: RetrievalBackend | None = None,
         reranker: Reranker | None = None,
+        weights: RouteWeights | None = None,
     ) -> None:
         self.catalog = catalog
         self.backend = backend or LocalTokenBackend()
         self.reranker = reranker or default_reranker()
+        self.weights = weights or RouteWeights.from_env()
 
     def route(
         self,
@@ -101,13 +170,19 @@ class Router:
         query_tokens = unique_tokens(query)
         backend_hits = {row["skill_id"]: row for row in self.backend.search(query, skills, limit=limit * 2)}
         candidates: list[RouteCandidate] = []
+        weights = self.weights
         for skill in skills:
             lexical = lexical_score(query_tokens, skill)
             backend_hit = backend_hits.get(skill.id)
             semantic = semantic_score(backend_hit)
             repo_context_score = repo_score(repo_context, skill)
             graph = graph_score(skill)
-            total = (lexical * 0.5) + (semantic * 0.25) + (repo_context_score * 0.15) + (graph * 0.10)
+            total = (
+                (lexical * weights.lexical)
+                + (semantic * weights.semantic)
+                + (repo_context_score * weights.repo_context)
+                + (graph * weights.graph)
+            )
             if total <= 0:
                 continue
             evidence = evidence_for(query_tokens, skill.excerpts)
@@ -144,9 +219,13 @@ class Router:
     def _needs_clarification(self, candidates: list[RouteCandidate]) -> bool:
         if not candidates:
             return True
-        if candidates[0].confidence < 0.18:
+        if candidates[0].confidence < self.weights.confidence_floor:
             return True
-        return len(candidates) > 1 and abs(candidates[0].confidence - candidates[1].confidence) < 0.025
+        return (
+            len(candidates) > 1
+            and abs(candidates[0].confidence - candidates[1].confidence)
+            < self.weights.clarification_gap
+        )
 
     def _clarification_questions(
         self,

--- a/src/skillroute/tuning.py
+++ b/src/skillroute/tuning.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import product
+from pathlib import Path
+from typing import Any
+
+from skillroute.backends import RetrievalBackend
+from skillroute.catalog import Catalog
+from skillroute.evals import load_cases
+from skillroute.routing import DEFAULT_WEIGHTS, Router, RouteWeights
+
+# Threshold grids explored alongside the blend weights. Small on purpose: the
+# eval corpora are small, so coarse steps avoid overfitting to a handful of
+# cases while still moving the clarification behavior.
+CONFIDENCE_FLOORS = (0.10, 0.15, 0.18, 0.22, 0.28)
+CLARIFICATION_GAPS = (0.01, 0.025, 0.05)
+
+
+@dataclass(frozen=True, slots=True)
+class TuneResult:
+    weights: dict[str, float]
+    passed: int
+    total: int
+    mean_reciprocal_rank: float
+    clarification_accuracy: float
+    score: float
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "weights": self.weights,
+            "passed": self.passed,
+            "total": self.total,
+            "mean_reciprocal_rank": round(self.mean_reciprocal_rank, 4),
+            "clarification_accuracy": round(self.clarification_accuracy, 4),
+            "score": round(self.score, 4),
+        }
+
+
+def iter_blend_grid(step: float = 0.2) -> Iterator[dict[str, float]]:
+    """Yield blend weights on the unit simplex at the given step.
+
+    lexical + semantic + repo_context + graph always sum to 1.0 so confidence
+    calibration stays comparable across the whole grid.
+    """
+    if step <= 0 or step > 1:
+        raise ValueError("step must be in (0, 1]")
+    steps = round(1.0 / step)
+    for lexical_index in range(steps + 1):
+        for semantic_index in range(steps + 1 - lexical_index):
+            for repo_index in range(steps + 1 - lexical_index - semantic_index):
+                graph_index = steps - lexical_index - semantic_index - repo_index
+                yield {
+                    "lexical": round(lexical_index * step, 6),
+                    "semantic": round(semantic_index * step, 6),
+                    "repo_context": round(repo_index * step, 6),
+                    "graph": round(graph_index * step, 6),
+                }
+
+
+def evaluate_weights(
+    catalog: Catalog,
+    backend: RetrievalBackend | None,
+    cases: list[dict[str, Any]],
+    weights: RouteWeights,
+) -> tuple[int, float, float]:
+    """Score one weight set against eval cases.
+
+    Returns (passed_count, mean_reciprocal_rank, clarification_accuracy).
+    Routes are run with record_trace=False so tuning never pollutes traces.
+    """
+    router = Router(catalog, backend=backend, weights=weights)
+    passed = 0
+    reciprocal_ranks: list[float] = []
+    clarification_hits = 0
+    for case in cases:
+        response = router.route(
+            case["request"],
+            repo=case.get("repo"),
+            limit=int(case.get("limit", 5)),
+            record_trace=False,
+        )
+        expected_names = case.get("expected_skill_names", [])
+        expected_ids = case.get("expected_skill_ids", [])
+        candidate_names = [candidate.name for candidate in response.candidates]
+        candidate_ids = [candidate.skill_id for candidate in response.candidates]
+
+        rank_pass = all(name in candidate_names for name in expected_names) and all(
+            skill_id in candidate_ids for skill_id in expected_ids
+        )
+        expected_clarification = bool(case.get("expect_clarification", False))
+        clarification_ok = response.clarification_needed is expected_clarification
+        if rank_pass and clarification_ok:
+            passed += 1
+        if clarification_ok:
+            clarification_hits += 1
+        reciprocal_ranks.append(
+            reciprocal_rank(candidate_names, candidate_ids, expected_names, expected_ids)
+        )
+    total = len(cases) or 1
+    mean_reciprocal_rank = sum(reciprocal_ranks) / total
+    clarification_accuracy = clarification_hits / total
+    return passed, mean_reciprocal_rank, clarification_accuracy
+
+
+def reciprocal_rank(
+    candidate_names: list[str],
+    candidate_ids: list[str],
+    expected_names: list[str],
+    expected_ids: list[str],
+) -> float:
+    """Reciprocal rank of the first expected candidate; 1.0 for empty expectations."""
+    if not expected_names and not expected_ids:
+        return 1.0
+    for position, (name, skill_id) in enumerate(zip(candidate_names, candidate_ids), start=1):
+        if name in expected_names or skill_id in expected_ids:
+            return 1.0 / position
+    return 0.0
+
+
+def tune_weights(
+    catalog: Catalog,
+    cases_path: Path,
+    backend: RetrievalBackend | None = None,
+    step: float = 0.2,
+) -> list[TuneResult]:
+    """Grid-search blend weights and thresholds against golden-route cases.
+
+    The built-in default weights are always evaluated first so they can only be
+    displaced by a weight set that scores strictly better (or ties and sits
+    closer to the defaults, which the defaults always win). Results are sorted
+    best-first; ties prefer weight sets closer to the built-in defaults so
+    tuning never changes behavior without evidence.
+    """
+    cases = load_cases(cases_path)
+    if not cases:
+        return []
+    results: list[TuneResult] = []
+    default_weights = RouteWeights()
+    passed, mrr, clarification_accuracy = evaluate_weights(catalog, backend, cases, default_weights)
+    results.append(
+        TuneResult(
+            weights=default_weights.to_json(),
+            passed=passed,
+            total=len(cases),
+            mean_reciprocal_rank=mrr,
+            clarification_accuracy=clarification_accuracy,
+            score=passed / len(cases) + mrr + 0.25 * clarification_accuracy,
+        )
+    )
+    for blend in iter_blend_grid(step):
+        if blend == {name: DEFAULT_WEIGHTS[name] for name in ("lexical", "semantic", "repo_context", "graph")}:
+            continue  # evaluated above
+        for floor, gap in product(CONFIDENCE_FLOORS, CLARIFICATION_GAPS):
+            weights = RouteWeights.from_overrides(
+                {**blend, "confidence_floor": floor, "clarification_gap": gap}
+            )
+            passed, mrr, clarification_accuracy = evaluate_weights(catalog, backend, cases, weights)
+            score = passed / len(cases) + mrr + 0.25 * clarification_accuracy
+            results.append(
+                TuneResult(
+                    weights=weights.to_json(),
+                    passed=passed,
+                    total=len(cases),
+                    mean_reciprocal_rank=mrr,
+                    clarification_accuracy=clarification_accuracy,
+                    score=score,
+                )
+            )
+    results.sort(key=lambda result: (-result.score, distance_from_defaults(result.weights)))
+    return results
+
+
+def distance_from_defaults(weights: dict[str, float]) -> float:
+    """L2 distance from the built-in defaults, used as a deterministic tiebreak."""
+    return sum(
+        (weights.get(name, default) - default) ** 2 for name, default in DEFAULT_WEIGHTS.items()
+    ) ** 0.5

--- a/src/skillroute/tuning.py
+++ b/src/skillroute/tuning.py
@@ -38,24 +38,34 @@ class TuneResult:
         }
 
 
+def grid_divisions(step: float) -> int:
+    """Number of grid divisions for ``step``, i.e. the effective step is 1/N."""
+    if step <= 0 or step > 1:
+        raise ValueError("step must be in (0, 1]")
+    return max(1, round(1.0 / step))
+
+
 def iter_blend_grid(step: float = 0.2) -> Iterator[dict[str, float]]:
     """Yield blend weights on the unit simplex at the given step.
 
     lexical + semantic + repo_context + graph always sum to 1.0 so confidence
-    calibration stays comparable across the whole grid.
+    calibration stays comparable across the whole grid. A step that does not
+    divide 1 evenly is snapped to the nearest 1/N (0.3 becomes 1/3, 0.4 becomes
+    1/2): weights come off the integer grid rather than from repeated addition
+    of ``step``, which would have them summing to 0.9 or 1.2 instead. Values
+    are rounded to 9 places, well inside any step the grid actually resolves,
+    so a blend of thirds still sums to 1.0 within 1e-9.
     """
-    if step <= 0 or step > 1:
-        raise ValueError("step must be in (0, 1]")
-    steps = round(1.0 / step)
+    steps = grid_divisions(step)
     for lexical_index in range(steps + 1):
         for semantic_index in range(steps + 1 - lexical_index):
             for repo_index in range(steps + 1 - lexical_index - semantic_index):
                 graph_index = steps - lexical_index - semantic_index - repo_index
                 yield {
-                    "lexical": round(lexical_index * step, 6),
-                    "semantic": round(semantic_index * step, 6),
-                    "repo_context": round(repo_index * step, 6),
-                    "graph": round(graph_index * step, 6),
+                    "lexical": round(lexical_index / steps, 9),
+                    "semantic": round(semantic_index / steps, 9),
+                    "repo_context": round(repo_index / steps, 9),
+                    "graph": round(graph_index / steps, 9),
                 }
 
 
@@ -149,13 +159,19 @@ def tune_weights(
             score=passed / len(cases) + mrr + 0.25 * clarification_accuracy,
         )
     )
+    # Dedupe on the whole weight set, not on the blend alone: when the step
+    # puts the default blend on the grid, its non-default floor/gap pairings
+    # are still worth exploring -- only the exact default was scored above.
+    seen = {weights_key(default_weights)}
     for blend in iter_blend_grid(step):
-        if blend == {name: DEFAULT_WEIGHTS[name] for name in ("lexical", "semantic", "repo_context", "graph")}:
-            continue  # evaluated above
         for floor, gap in product(CONFIDENCE_FLOORS, CLARIFICATION_GAPS):
             weights = RouteWeights.from_overrides(
                 {**blend, "confidence_floor": floor, "clarification_gap": gap}
             )
+            key = weights_key(weights)
+            if key in seen:
+                continue
+            seen.add(key)
             passed, mrr, clarification_accuracy = evaluate_weights(catalog, backend, cases, weights)
             score = passed / len(cases) + mrr + 0.25 * clarification_accuracy
             results.append(
@@ -170,6 +186,11 @@ def tune_weights(
             )
     results.sort(key=lambda result: (-result.score, distance_from_defaults(result.weights)))
     return results
+
+
+def weights_key(weights: RouteWeights) -> tuple[tuple[str, float], ...]:
+    """Hashable identity of a full weight set, for deduping the search grid."""
+    return tuple(sorted(weights.to_json().items()))
 
 
 def distance_from_defaults(weights: dict[str, float]) -> float:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -874,3 +874,21 @@ def test_cli_eval_tune_json_output(
         "confidence_floor",
         "clarification_gap",
     }
+
+
+def test_cli_route_reports_bad_weights_env_cleanly(
+    tmp_path: Path, fixture_skills_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo in SKILLROUTE_WEIGHTS should read like any other config error."""
+    catalog_path = tmp_path / "catalog.db"
+    main(["--catalog", str(catalog_path), "index", "--root", str(fixture_skills_root)])
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", "{not json")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--catalog", str(catalog_path), "route", "Build an MCP server"])
+    assert "SKILLROUTE_WEIGHTS is not valid JSON" in str(excinfo.value)
+
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", '{"lexical": -1}')
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--catalog", str(catalog_path), "search", "mcp"])
+    assert "must be >= 0" in str(excinfo.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -709,3 +709,66 @@ def test_cli_traces_list_and_show_text_output(
     show_output = capsys.readouterr().out
     assert "Trace 1" in show_output
     assert "request: Build an MCP server with tools" in show_output
+
+
+def test_cli_eval_tune_prints_best_weights(
+    tmp_path: Path, fixture_skills_root: Path, capsys
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    cases = Path(__file__).parent / "fixtures" / "golden_routes.json"
+    main(
+        [
+            "--catalog",
+            str(catalog_path),
+            "eval",
+            "tune",
+            "--fresh",
+            "--index-root",
+            str(fixture_skills_root),
+            "--cases",
+            str(cases),
+            "--step",
+            "0.5",
+            "--top",
+            "2",
+        ]
+    )
+    output = capsys.readouterr().out
+    assert "Top 2 weight sets (4 cases):" in output
+    assert "Apply with: SKILLROUTE_WEIGHTS=" in output
+
+
+def test_cli_eval_tune_json_output(
+    tmp_path: Path, fixture_skills_root: Path, capsys
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    cases = Path(__file__).parent / "fixtures" / "golden_routes.json"
+    main(
+        [
+            "--catalog",
+            str(catalog_path),
+            "eval",
+            "tune",
+            "--fresh",
+            "--index-root",
+            str(fixture_skills_root),
+            "--cases",
+            str(cases),
+            "--step",
+            "0.5",
+            "--top",
+            "1",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 1
+    assert payload[0]["passed"] == payload[0]["total"]
+    assert set(payload[0]["weights"]) == {
+        "lexical",
+        "semantic",
+        "repo_context",
+        "graph",
+        "confidence_floor",
+        "clarification_gap",
+    }

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skillroute.catalog import Catalog
+from skillroute.routing import DEFAULT_WEIGHTS, Router, RouteWeights
+from skillroute.tuning import (
+    distance_from_defaults,
+    evaluate_weights,
+    iter_blend_grid,
+    reciprocal_rank,
+    tune_weights,
+)
+
+
+def test_route_weights_defaults_match_history() -> None:
+    weights = RouteWeights()
+    assert weights.to_json() == DEFAULT_WEIGHTS
+    assert weights.lexical == 0.5
+    assert weights.semantic == 0.25
+    assert weights.confidence_floor == 0.18
+    assert weights.clarification_gap == 0.025
+
+
+def test_route_weights_from_overrides_partial() -> None:
+    weights = RouteWeights.from_overrides({"lexical": 0.7, "semantic": 0.3})
+    assert weights.lexical == 0.7
+    assert weights.semantic == 0.3
+    assert weights.repo_context == DEFAULT_WEIGHTS["repo_context"]
+
+
+def test_route_weights_rejects_unknown_keys() -> None:
+    with pytest.raises(ValueError, match="Unknown route weight keys"):
+        RouteWeights.from_overrides({"lexical": 0.5, "bogus": 1.0})
+
+
+def test_route_weights_rejects_negative_and_non_numeric() -> None:
+    with pytest.raises(ValueError, match="must be >= 0"):
+        RouteWeights.from_overrides({"graph": -0.1})
+    with pytest.raises(ValueError, match="must be a number"):
+        RouteWeights.from_overrides({"graph": "lots"})
+
+
+def test_route_weights_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", json.dumps({"lexical": 0.8, "semantic": 0.2}))
+    weights = RouteWeights.from_env()
+    assert weights.lexical == 0.8
+    assert weights.semantic == 0.2
+
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", "")
+    assert RouteWeights.from_env() == RouteWeights()
+
+
+def test_route_weights_from_env_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", "{not json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        RouteWeights.from_env()
+
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", "[1, 2]")
+    with pytest.raises(TypeError, match="JSON object"):
+        RouteWeights.from_env()
+
+
+def test_router_weights_change_ranking(indexed_catalog: Catalog) -> None:
+    """Zeroing the lexical weight must change the score blend."""
+    request = "Build an MCP server with tools"
+    baseline = Router(indexed_catalog).route(request, record_trace=False)
+    reweighted = Router(
+        indexed_catalog,
+        weights=RouteWeights.from_overrides({"lexical": 0.0, "semantic": 1.0}),
+    ).route(request, record_trace=False)
+
+    baseline_scores = [c.score_breakdown.total for c in baseline.candidates]
+    reweighted_scores = [c.score_breakdown.total for c in reweighted.candidates]
+    assert baseline_scores != reweighted_scores
+
+
+def test_iter_blend_grid_covers_simplex() -> None:
+    grid = list(iter_blend_grid(step=0.5))
+    # Compositions of 1.0 into 4 parts at step 0.5 (2 units): C(2+3, 3) = 10.
+    assert len(grid) == 10
+    for blend in grid:
+        assert sum(blend.values()) == pytest.approx(1.0)
+        assert all(value >= 0 for value in blend.values())
+    assert {"lexical": 1.0, "semantic": 0.0, "repo_context": 0.0, "graph": 0.0} in grid
+
+
+def test_iter_blend_grid_rejects_bad_step() -> None:
+    with pytest.raises(ValueError, match="step"):
+        list(iter_blend_grid(step=0.0))
+    with pytest.raises(ValueError, match="step"):
+        list(iter_blend_grid(step=1.5))
+
+
+def test_reciprocal_rank() -> None:
+    assert reciprocal_rank(["a", "b"], ["a-id", "b-id"], ["b"], []) == 0.5
+    assert reciprocal_rank(["a", "b"], ["a-id", "b-id"], [], ["b-id"]) == 0.5
+    assert reciprocal_rank(["a"], ["a-id"], ["missing"], []) == 0.0
+    assert reciprocal_rank([], [], [], []) == 1.0
+
+
+def test_evaluate_weights_counts_passes(indexed_catalog: Catalog) -> None:
+    cases = json.loads(
+        (Path(__file__).parent / "fixtures" / "golden_routes.json").read_text(encoding="utf-8")
+    )
+    passed, mrr, clarification_accuracy = evaluate_weights(
+        indexed_catalog, None, cases, RouteWeights()
+    )
+    assert passed == len(cases)
+    assert mrr > 0
+    assert clarification_accuracy == 1.0
+
+
+def test_distance_from_defaults() -> None:
+    assert distance_from_defaults(DEFAULT_WEIGHTS) == 0.0
+    moved = dict(DEFAULT_WEIGHTS)
+    moved["lexical"] = DEFAULT_WEIGHTS["lexical"] + 0.3
+    assert distance_from_defaults(moved) == pytest.approx(0.3)
+
+
+def test_tune_weights_prefers_defaults_when_all_pass(
+    tmp_path: Path, fixture_skills_root: Path
+) -> None:
+    catalog = Catalog(tmp_path / "catalog.db")
+    catalog.index_root(fixture_skills_root)
+    cases_path = Path(__file__).parent / "fixtures" / "golden_routes.json"
+
+    results = tune_weights(catalog, cases_path, step=0.5)
+
+    assert results
+    best = results[0]
+    assert best.passed == best.total
+    scores = [result.score for result in results]
+    assert scores == sorted(scores, reverse=True)
+    # Default weights pass every case, so the tiebreak keeps them on top.
+    assert best.weights == DEFAULT_WEIGHTS
+
+
+def test_tune_weights_empty_cases(tmp_path: Path) -> None:
+    catalog = Catalog(tmp_path / "catalog.db")
+    empty_cases = tmp_path / "empty.json"
+    empty_cases.write_text("[]", encoding="utf-8")
+
+    assert tune_weights(catalog, empty_cases) == []

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -8,8 +8,11 @@ import pytest
 from skillroute.catalog import Catalog
 from skillroute.routing import DEFAULT_WEIGHTS, Router, RouteWeights
 from skillroute.tuning import (
+    CLARIFICATION_GAPS,
+    CONFIDENCE_FLOORS,
     distance_from_defaults,
     evaluate_weights,
+    grid_divisions,
     iter_blend_grid,
     reciprocal_rank,
     tune_weights,
@@ -42,6 +45,25 @@ def test_route_weights_rejects_negative_and_non_numeric() -> None:
         RouteWeights.from_overrides({"graph": -0.1})
     with pytest.raises(ValueError, match="must be a number"):
         RouteWeights.from_overrides({"graph": "lots"})
+
+
+def test_route_weights_rejects_non_finite() -> None:
+    """inf/NaN slip past a >= 0 check and would poison every score."""
+    for bad in (float("inf"), float("-inf"), float("nan")):
+        with pytest.raises(ValueError, match="must be finite"):
+            RouteWeights.from_overrides({"lexical": bad})
+
+
+def test_route_weights_from_env_rejects_non_finite(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Python's json accepts both of these spellings even though neither is
+    # standard JSON, so the env path has to reject them itself.
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", '{"lexical": 1e999}')
+    with pytest.raises(ValueError, match="must be finite"):
+        RouteWeights.from_env()
+
+    monkeypatch.setenv("SKILLROUTE_WEIGHTS", '{"lexical": NaN}')
+    with pytest.raises(ValueError, match="must be finite"):
+        RouteWeights.from_env()
 
 
 def test_route_weights_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -86,6 +108,28 @@ def test_iter_blend_grid_covers_simplex() -> None:
         assert sum(blend.values()) == pytest.approx(1.0)
         assert all(value >= 0 for value in blend.values())
     assert {"lexical": 1.0, "semantic": 0.0, "repo_context": 0.0, "graph": 0.0} in grid
+
+
+def test_iter_blend_grid_stays_on_simplex_for_awkward_steps() -> None:
+    """A step that does not divide 1 evenly must still sum to 1.0, not 0.9/1.2.
+
+    Multiplying an index by the raw step made every blend sum to 0.9 at
+    step=0.3 and 1.2 at step=0.6, silently rescaling confidence across runs.
+    """
+    for step in (0.3, 0.4, 0.6, 0.7):
+        grid = list(iter_blend_grid(step=step))
+        assert grid
+        for blend in grid:
+            assert sum(blend.values()) == pytest.approx(1.0, abs=1e-6)
+            assert all(value >= 0 for value in blend.values())
+
+
+def test_grid_divisions_snaps_step_to_nearest_reciprocal() -> None:
+    assert grid_divisions(0.2) == 5
+    assert grid_divisions(0.5) == 2
+    assert grid_divisions(0.3) == 3  # snapped to 1/3
+    assert grid_divisions(0.7) == 1  # snapped to 1/1
+    assert grid_divisions(1.0) == 1
 
 
 def test_iter_blend_grid_rejects_bad_step() -> None:
@@ -137,6 +181,44 @@ def test_tune_weights_prefers_defaults_when_all_pass(
     assert scores == sorted(scores, reverse=True)
     # Default weights pass every case, so the tiebreak keeps them on top.
     assert best.weights == DEFAULT_WEIGHTS
+
+
+def test_tune_weights_explores_thresholds_for_the_default_blend(
+    tmp_path: Path, fixture_skills_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default blend with non-default thresholds must stay reachable.
+
+    Skipping the default blend wholesale (rather than the exact default weight
+    set) meant a corpus whose best result is a clarification-threshold change
+    at the default ranking weights could never surface it. Only steps that put
+    the default blend on the grid hit this, so the grid is stubbed to it.
+    """
+    catalog = Catalog(tmp_path / "catalog.db")
+    catalog.index_root(fixture_skills_root)
+    cases_path = Path(__file__).parent / "fixtures" / "golden_routes.json"
+    default_blend = {
+        name: DEFAULT_WEIGHTS[name]
+        for name in ("lexical", "semantic", "repo_context", "graph")
+    }
+    monkeypatch.setattr(
+        "skillroute.tuning.iter_blend_grid", lambda step=0.2: iter([dict(default_blend)])
+    )
+
+    results = tune_weights(catalog, cases_path)
+
+    # The default weight set, plus every other floor x gap pairing of the same
+    # blend -- 5 floors x 3 gaps, with the exact default deduped out.
+    assert len(results) == len(CONFIDENCE_FLOORS) * len(CLARIFICATION_GAPS)
+    assert all(
+        {name: result.weights[name] for name in default_blend} == default_blend
+        for result in results
+    )
+    thresholds = {
+        (result.weights["confidence_floor"], result.weights["clarification_gap"])
+        for result in results
+    }
+    assert len(thresholds) == len(results), "duplicate threshold pairs were scored"
+    assert (DEFAULT_WEIGHTS["confidence_floor"], DEFAULT_WEIGHTS["clarification_gap"]) in thresholds
 
 
 def test_tune_weights_empty_cases(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The routing blend weights (`lexical 0.5 / semantic 0.25 / repo_context 0.15 / graph 0.10`), the clarification confidence floor (`0.18`), and the tie gap (`0.025`) were hardcoded constants in `routing.py` — chosen, not learned, with no way to inspect, override, or validate them against eval evidence. This PR makes them a first-class, tunable part of the system without changing any default behavior.

### What's in here

- **`RouteWeights`** (frozen dataclass) replaces every hardcoded constant; defaults are byte-identical to previous behavior. Passed via `Router(weights=...)` or loaded from the `SKILLROUTE_WEIGHTS` env var (JSON object, subset of keys allowed, unknown keys / negative values rejected with clear errors).
- **`skillroute eval tune`** — new subcommand that grid-searches:
  - blend weights on the unit simplex (`--step`, default 0.2 → 285 compositions) so confidence calibration stays comparable across the grid
  - crossed with confidence-floor × clarification-gap threshold grids
  - scored by `passed/total + mean reciprocal rank + 0.25 × clarification accuracy`
  - the built-in defaults are always evaluated first and win ties, so tuning can only *displace* the defaults with strictly better evidence — it never changes behavior for free
  - routes run with `record_trace=False` so tuning never pollutes route traces
  - `--top N`, `--json`, `--fresh`, `--index-root`, `--backend` all supported; prints a ready-to-paste `SKILLROUTE_WEIGHTS=...` for the winner

### Verification (local)

- `pytest`: **147 passed**, coverage **88.7%** (`tuning.py` 98%, `routing.py` 97%)
- `ruff` + `mypy`: clean
- Golden evals still pass: 3/3 on `examples/evals/golden_routes.json`
- Ran the tuner for real against the example corpus:

```text
Top 3 weight sets (3 cases):
1. score=2.2500 passed=3/3   weights: {lexical: 0.5, semantic: 0.25, ...}   <- defaults win the tie
2. score=2.2500 passed=3/3   weights: {lexical: 0.4, semantic: 0.2, ...}
3. score=2.2500 passed=3/3   weights: {lexical: 0.6, semantic: 0.2, ...}
```

(The 3-case example corpus is too small to discriminate — which is exactly the point: the tuner shows you that, instead of pretending a grid search found a winner. On a larger case file it ranks the alternatives by real evidence.)

### Example

```bash
SKILLROUTE_WEIGHTS='{"lexical": 0.6, "semantic": 0.2, "repo_context": 0.1, "graph": 0.1}'   skillroute route "Build an MCP server"
```

### Notes for reviewers

- Default behavior is unchanged; this is purely additive.
- Independent of #40 (FTS5 backend) — but once that lands, tuning gains a second dimension (weights × backend) to explore.
- The intended workflow over time: grow the golden case file as routing regressions appear, then let `eval tune` earn any weight change.