### PR TITLE
feat(0.2): S0 foundations, S1 harness packs + doctor, S2 distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,22 @@ jobs:
         with:
           node-version: "22"
 
+      # The tag is the only thing a human types here, and the version published
+      # comes from package metadata, not from the tag. Without this check,
+      # tagging v0.2.0 while pyproject.toml still says 0.1.0 publishes 0.1.0 to
+      # PyPI under a release titled v0.2.0 -- and a PyPI version can never be
+      # reused, so there is no clean recovery.
+      - name: Verify the tag matches both package versions
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          py=$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          npm_version=$(node -p "require('./mcp/package.json').version")
+          echo "tag=$tag pyproject=$py package.json=$npm_version"
+          if [ "$tag" != "$py" ] || [ "$tag" != "$npm_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME disagrees with pyproject.toml ($py) and/or mcp/package.json ($npm_version)."
+            exit 1
+          fi
+
       - name: Build sdist and wheel (bundles the web UI)
         run: uv build
 
@@ -99,6 +115,10 @@ jobs:
     if: vars.NPM_PUBLISH == 'true'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      # npm trusted publishing is OIDC: this replaces NPM_TOKEN entirely, so
+      # there is no long-lived credential in repo secrets to leak or rotate.
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -106,13 +126,17 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "22.14.0"
           registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing needs npm >= 11.5.1, and Node 22 still bundles npm
+      # 10.x. Without this the publish fails on a message that does not mention
+      # the npm version at all.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Publish
         working-directory: mcp
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm ci
           npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Catalog schema v2 with real migration machinery. `skillroute.migrations`
+  defines ordered, named migrations; `Catalog.initialize()` detects the on-disk
+  version, takes a write lock (`BEGIN IMMEDIATE`) so a concurrent index and UI
+  server cannot both migrate, backs the file up before altering it, and refuses
+  a catalog written by a newer SkillRoute instead of corrupting it. Existing v1
+  catalogs upgrade in place; their traces are unpacked into the new columns
+  rather than discarded.
+- Route traces now record who asked and what happened: `harness_id`,
+  `harness_version`, `surface`, `request_text`, `top_confidence`,
+  `second_confidence`, `catalog_fingerprint`, and the routing weights in effect.
+  A new `route_trace_candidates` table denormalizes every ranked candidate and
+  its score breakdown so analytics can use SQL instead of parsing response
+  blobs. `skillroute route --harness <id>` and `SKILLROUTE_HARNESS` set the
+  attribution; an unknown caller stays unknown rather than erroring.
+- `Catalog.record_outcome()` and a `route_outcomes` table, so an agent can
+  report which skill it actually used. The rank it was offered at is resolved
+  from the recorded candidates rather than trusted from the caller.
+- `route_trace_daily` aggregates every route on the day it happens. Raw traces
+  are still capped, but the rollup is not, so route counts, clarification rates,
+  and confidence distributions survive pruning and remain answerable over time.
+
+### Changed
+
+- Raw route-trace retention raised from 1,000 to 20,000, configurable via
+  `SKILLROUTE_MAX_TRACES` (`0` disables pruning). 1,000 rows was a few days of
+  one active harness — too short a horizon for any question about change over
+  time. Pruning is now amortized across inserts rather than run on every one, so
+  the table may sit slightly above the cap between prunes.
+
+### Added
+
 - SQLite FTS5 retrieval backend (`--backend fts5`, alias `sqlite-fts5`):
   local BM25 ranking with term-frequency and document-length normalization on
   top of the existing token-overlap lexical score. Query input is escaped so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `route_trace_daily` aggregates every route on the day it happens. Raw traces
   are still capped, but the rollup is not, so route counts, clarification rates,
   and confidence distributions survive pruning and remain answerable over time.
+- SQLite FTS5 retrieval backend (`--backend fts5`, alias `sqlite-fts5`):
+  local BM25 ranking with term-frequency and document-length normalization on
+  top of the existing token-overlap lexical score. Query input is escaped so
+  FTS5 syntax in requests is treated as literal terms. Available in the CLI,
+  bridge, and MCP server backend choices.
+- Routing weights are now explicit and tunable: `RouteWeights` replaces the
+  hardcoded blend constants, `SKILLROUTE_WEIGHTS` overrides them per process,
+  and `skillroute eval tune` grid-searches weights against golden route cases
+  so changes are backed by eval evidence. Defaults are unchanged.
 
 ### Changed
 
@@ -79,18 +88,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `skillroute.client_setup` and `skillroute.mcp_setup` modules are now shims
   re-exporting `skillroute.harness_setup` and `skillroute.harness_render`. All
   are removed in 0.3.
-
-### Added
-
-- SQLite FTS5 retrieval backend (`--backend fts5`, alias `sqlite-fts5`):
-  local BM25 ranking with term-frequency and document-length normalization on
-  top of the existing token-overlap lexical score. Query input is escaped so
-  FTS5 syntax in requests is treated as literal terms. Available in the CLI,
-  bridge, and MCP server backend choices.
-- Routing weights are now explicit and tunable: `RouteWeights` replaces the
-  hardcoded blend constants, `SKILLROUTE_WEIGHTS` overrides them per process,
-  and `skillroute eval tune` grid-searches weights against golden route cases
-  so changes are backed by eval evidence. Defaults are unchanged.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-platform config paths. Manifests declare `macos`/`linux`/`windows`
   variants and the most specific match wins; `skillroute harness show --platform`
   renders for a platform you are not on. v0.1 detection was macOS-only.
-- `skillroute harness list | detect | show | install`, plus
+- `skillroute harness list | detect | show | install | doctor`, plus
   [docs/harnesses.md](docs/harnesses.md) covering how to add a harness.
+- `skillroute harness doctor` verifies a pack still matches reality: the manifest
+  declares a path for the current platform, every mode still renders, and the
+  config on disk names our server. It then runs the exact server command the
+  config points at and confirms it answers an MCP `initialize` handshake — the
+  one check that inspection cannot fake. Config paths for fourteen tools rot
+  silently, because `harness install` keeps reporting success while writing to a
+  file the tool no longer reads. An absent or unconfigured harness warns rather
+  than fails, so a non-zero exit means real breakage and the command works as a
+  CI gate (`--json`, `--no-probe`).
 - Catalog schema v2 with real migration machinery. `skillroute.migrations`
   defines ordered, named migrations; `Catalog.initialize()` detects the on-disk
   version, takes a write lock (`BEGIN IMMEDIATE`) so a concurrent index and UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Harness packs.** Every agent tool SkillRoute supports is now one declarative
+  manifest in `harnesses/*.toml` describing detection, per-platform config paths,
+  and which install modes it offers. v0.1 encoded this as a hardcoded if/elif
+  chain plus a per-client detection function, so adding a tool meant editing
+  around seven places across two modules and three docs; adding one that fits an
+  existing config shape is now a data change with no Python. Six of the fourteen
+  shipped harnesses reuse the same shape unchanged. `tests/test_harnesses.py` is
+  parametrized over whatever is in `harnesses/`, so a new manifest is covered
+  automatically.
+- Seven new harnesses: `pi`, `hermes`, `opencode`, `goose`, `gemini-cli`, `zed`,
+  and `amp` — joining the seven from v0.1, all migrated to manifests with
+  byte-identical generated output.
+- Install modes beyond MCP: `acp`, `skills` (native skills-directory discovery
+  and projection), `hook`, `extension`, and `router_skill`. Where a harness lets
+  you register an extra skills directory (Hermes `external_dirs`, Pi's settings),
+  SkillRoute registers rather than copying — no duplication, no sync drift.
+- Cross-platform config paths. Manifests declare `macos`/`linux`/`windows`
+  variants and the most specific match wins; `skillroute harness show --platform`
+  renders for a platform you are not on. v0.1 detection was macOS-only.
+- `skillroute harness list | detect | show | install`, plus
+  [docs/harnesses.md](docs/harnesses.md) covering how to add a harness.
 - Catalog schema v2 with real migration machinery. `skillroute.migrations`
   defines ordered, named migrations; `Catalog.initialize()` detects the on-disk
   version, takes a write lock (`BEGIN IMMEDIATE`) so a concurrent index and UI
@@ -32,11 +53,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Skill discovery is derived from the harness manifests instead of a hardcoded
+  three-entry tuple, growing from 3 roots to 10 — including `~/.claude/skills`,
+  which v0.1 never scanned.
 - Raw route-trace retention raised from 1,000 to 20,000, configurable via
   `SKILLROUTE_MAX_TRACES` (`0` disables pruning). 1,000 rows was a few days of
   one active harness — too short a horizon for any question about change over
   time. Pruning is now amortized across inserts rather than run on every one, so
   the table may sit slightly above the cap between prunes.
+
+### Deprecated
+
+- `skillroute mcp config --client <id>` in favour of `skillroute harness show`
+  and `skillroute harness install`. Output is unchanged and the deprecation
+  notice goes to stderr, so `--json` stdout stays machine-parseable. The
+  `skillroute.client_setup` and `skillroute.mcp_setup` modules are now shims
+  re-exporting `skillroute.harness_setup` and `skillroute.harness_render`. All
+  are removed in 0.3.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   file the tool no longer reads. An absent or unconfigured harness warns rather
   than fails, so a non-zero exit means real breakage and the command works as a
   CI gate (`--json`, `--no-probe`).
+- `--server-source {local,npx}` on `harness show` and `harness install` chooses
+  whether a generated config starts the MCP server from a built checkout or from
+  the published `@skillroute/mcp-server` via `npx -y`. v0.1 hardcoded the
+  checkout path, which is why nothing outside a git clone could run SkillRoute.
+  The default stays `local` until the package is actually on npm, so this adds
+  the capability without emitting configs that resolve to nothing.
 - Catalog schema v2 with real migration machinery. `skillroute.migrations`
   defines ordered, named migrations; `Catalog.initialize()` detects the on-disk
   version, takes a write lock (`BEGIN IMMEDIATE`) so a concurrent index and UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The npm release job publishes via npm trusted publishing (OIDC) instead of a
+  long-lived `NPM_TOKEN` secret, so there is no static credential in repo
+  secrets to leak or rotate, and provenance attestations are generated
+  automatically. Requires `id-token: write` and npm ≥ 11.5.1, which Node 22 does
+  not bundle — the job upgrades npm explicitly.
+- The release workflow now fails if the pushed tag disagrees with the version in
+  `pyproject.toml` or `mcp/package.json`. The published version comes from
+  package metadata rather than the tag, so tagging `v0.2.0` against a `0.1.0`
+  pyproject would have published `0.1.0` under a release titled `v0.2.0` — and
+  a PyPI version can never be reused, so there is no clean recovery.
 - Skill discovery is derived from the harness manifests instead of a hardcoded
   three-entry tuple, growing from 3 roots to 10 — including `~/.claude/skills`,
   which v0.1 never scanned.

--- a/README.md
+++ b/README.md
@@ -92,14 +92,21 @@ uv run skillroute ui
 
 The bundled MCP server exposes three tools over stdio — `skillroute.route`,
 `skillroute.search`, and `skillroute.inspect_skill`. One command writes the
-config for your client (JSON edits are backed up first):
+config for your harness (JSON edits are backed up first):
 
 ```bash
-uv run skillroute mcp config --client claude-code
+uv run skillroute harness install claude-code
+uv run skillroute harness detect        # what is installed here
+uv run skillroute harness list          # everything SkillRoute knows about
 ```
 
-Supported clients: `claude-code` · `claude-desktop` · `codex` · `cursor` ·
-`ibm-bob` · `vscode` · `windsurf`
+Supported harnesses: `amp` · `claude-code` · `claude-desktop` · `codex` ·
+`cursor` · `gemini-cli` · `goose` · `hermes` · `ibm-bob` · `opencode` · `pi` ·
+`vscode` · `windsurf` · `zed`
+
+Each one is a single declarative manifest in [`harnesses/`](harnesses), so
+adding a new tool is usually a data change with no Python — see
+[Harness Packs](docs/harnesses.md).
 
 ## Route observability
 
@@ -146,7 +153,8 @@ flowchart LR
 | `skillroute traces list` | Inspect past routing decisions |
 | `skillroute eval run` | Golden-route evals against expected outcomes |
 | `skillroute backend status` | Retrieval backend health |
-| `skillroute mcp config --client <client>` | Configure your agent client |
+| `skillroute harness list` | Every harness SkillRoute supports, and its modes |
+| `skillroute harness install <harness>` | Configure a harness to use SkillRoute |
 | `skillroute ui` | Launch the Skill Atlas |
 
 ## Docs
@@ -154,6 +162,7 @@ flowchart LR
 | Guide | |
 | --- | --- |
 | [Getting Started](docs/getting-started.md) | Index, route, and inspect in five minutes |
+| [Harness Packs](docs/harnesses.md) | Supported harnesses, install modes, and how to add one |
 | [Agent Setup](docs/agent-setup.md) | Wire SkillRoute into your agent clients |
 | [MCP Server](docs/mcp-server.md) | Tools, transport, and configuration |
 | [Skill Atlas UI](docs/skill-atlas.md) | The graph explorer in depth |

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -1,0 +1,178 @@
+# Harness Packs
+
+A **harness** is an agent tool that can consume SkillRoute — Claude Code, Codex,
+Pi, Hermes, OpenCode, and the rest. Each one is described by a single declarative
+manifest in [`harnesses/`](../harnesses), so adding support for a new tool is
+usually a data change with no Python at all.
+
+```bash
+skillroute harness list                  # everything SkillRoute knows about
+skillroute harness list --mode skills    # only harnesses with a skills directory
+skillroute harness detect                # what is actually installed here
+skillroute harness show pi               # what setup would look like
+skillroute harness install pi --dry-run  # print, change nothing
+skillroute harness install pi --yes      # apply it
+```
+
+## Supported harnesses
+
+`first-party` harnesses support every mode that makes sense for them and are
+exercised end to end. `breadth` harnesses are MCP-only.
+
+| id | Name | Tier | Modes | Config shape |
+| --- | --- | --- | --- | --- |
+| `claude-code` | Claude Code | first-party | `hook` · `mcp` · `router_skill` · `skills` | `mcp_servers` |
+| `codex` | Codex | first-party | `mcp` · `router_skill` · `skills` | `codex_toml` |
+| `pi` | Pi | first-party | `extension` · `mcp` · `router_skill` · `skills` | `mcp_servers` |
+| `hermes` | Hermes Agent | first-party | `acp` · `mcp` · `router_skill` · `skills` | `yaml_map` |
+| `opencode` | OpenCode | first-party | `mcp` · `router_skill` · `skills` | `opencode_mcp` |
+| `amp` | Amp | breadth | `mcp` | `amp_mcp_servers` |
+| `claude-desktop` | Claude Desktop | breadth | `mcp` | `mcp_servers` |
+| `cursor` | Cursor | breadth | `mcp` | `mcp_servers` |
+| `gemini-cli` | Gemini CLI | breadth | `mcp` | `mcp_servers` |
+| `goose` | Goose | breadth | `mcp` | `yaml_map` |
+| `ibm-bob` | IBM Bob | breadth | `mcp` | `mcp_servers` |
+| `vscode` | VS Code | breadth | `mcp` | `vscode_servers` |
+| `windsurf` | Windsurf | breadth | `mcp` | `mcp_servers` |
+| `zed` | Zed | breadth | `acp` · `mcp` | `zed_context_servers` |
+
+The manifests are the source of truth; `skillroute harness list --json` always
+reflects what is actually installed.
+
+## Install modes
+
+A harness declares which of these it supports. `mcp` is the baseline.
+
+| Mode | What it does |
+| --- | --- |
+| `mcp` | Register the SkillRoute MCP server |
+| `acp` | Attach SkillRoute as an ACP routing-advisor agent |
+| `skills` | Read the harness's native skills directory, and optionally project a routed subset back |
+| `hook` | Install a lifecycle hook (Claude Code's `SessionStart`) |
+| `extension` | Install a harness-native extension package (Pi) |
+| `router_skill` | Drop in a generated `SKILL.md` that teaches the agent to ask SkillRoute first |
+
+## Adding a harness
+
+Most of the time this is one file.
+
+**1. Write `harnesses/<id>.toml`.** The filename stem must match `id`.
+
+```toml
+schema = 1
+id = "my-harness"
+display_name = "My Harness"
+tier = "unverified"          # first-party | breadth | unverified
+homepage = "https://example.com/docs"
+
+[detect]
+commands = ["my-harness"]                  # looked up on PATH
+client_names = ["my-harness"]              # MCP initialize clientInfo.name
+paths.all = ["~/.my-harness/config.json"]  # or paths.macos / .linux / .windows
+apps.macos = ["/Applications/My Harness.app"]
+
+[modes.mcp]
+setup_method = "json_merge"                # command | json_merge | print_only | dir_sync | package
+emitter = "mcp_servers"                    # a named config shape (see below)
+config_format = "json"
+config_path = "~/.my-harness/config.json"  # shown to the user
+write_path.all = "~/.my-harness/config.json"
+```
+
+**2. Run the conformance suite.** It is parametrized over whatever is in
+`harnesses/`, so your new file is picked up automatically:
+
+```bash
+uv run --extra dev pytest tests/test_harnesses.py -v
+```
+
+That checks the manifest validates, every placeholder resolves, the mode renders
+on all three platforms, detection finds it from its own declared paths, and it
+does not try to merge a format SkillRoute cannot write.
+
+**3. Verify against the real tool.**
+
+```bash
+skillroute harness show my-harness       # eyeball the snippet
+skillroute harness install my-harness    # then confirm the tool sees it
+```
+
+Once confirmed against the tool's own docs, promote `tier` off `unverified`.
+
+### Placeholders
+
+Any string value may contain these; anything else is a validation error.
+
+`{harness_id}` `{server_name}` `{catalog}` `{backend}` `{repo_root}` `{scope}`
+`{server_json}`, plus `{server_argv}`, which expands to multiple argv entries
+and is therefore only valid as a whole array element.
+
+### Config shapes (emitters)
+
+A manifest picks a shape by name. Six of the fourteen shipped harnesses reuse
+`mcp_servers` unchanged — if yours matches an existing shape, you write no code.
+
+| Emitter | Shape |
+| --- | --- |
+| `mcp_servers` | `{"mcpServers": {name: {...}}}` — the de facto standard |
+| `vscode_servers` | top-level `servers`, name embedded in the object |
+| `opencode_mcp` | nested under `mcp` with an explicit `type` |
+| `zed_context_servers` | `context_servers` |
+| `amp_mcp_servers` | `amp.mcpServers` |
+| `codex_toml` | a TOML snippet |
+| `yaml_map` | a YAML map under a configurable key |
+| `claude_session_start_hook` | a Claude Code hook entry |
+
+Extra literal keys go in `[modes.<mode>.extra]` and are folded into the emitted
+server object — that is how IBM Bob gets `cwd`/`disabled` and Codex gets its
+timeouts, without either needing its own emitter.
+
+If your harness genuinely needs a new shape, add one function to `EMITTERS` in
+`src/skillroute/harness_render.py` and a test pinning it. That is a deliberate,
+reviewable addition rather than routine work.
+
+### Two rules worth knowing
+
+**SkillRoute never rewrites your TOML or YAML.** `tomllib` cannot write, there
+is no YAML dependency, and hand-merging someone's config file is not worth the
+blast radius. Harnesses configured in those formats use `setup_method =
+"command"` (drive their own CLI) or `"print_only"` (print a snippet to paste).
+A conformance test enforces this.
+
+**Prefer registering a directory over copying files into one.** Hermes exposes
+`external_dirs` and Pi declares skill paths in its settings, so `[modes.skills]
+register_in` points SkillRoute's directory at them instead of duplicating
+bundles. No duplication, no sync drift.
+
+## Cross-platform paths
+
+Every path table accepts `all`, `macos`, `linux`, and `windows` keys, and the
+most specific match wins:
+
+```toml
+write_path.macos   = "~/.config/goose/config.yaml"
+write_path.linux   = "~/.config/goose/config.yaml"
+write_path.windows = "%APPDATA%/Block/goose/config/config.yaml"
+```
+
+Render for another platform without being on it:
+
+```bash
+skillroute harness show goose --platform windows --json
+```
+
+## Migrating from `skillroute mcp config`
+
+`skillroute mcp config --client <id>` still works and emits identical output,
+but it is deprecated and will be removed in 0.3. The deprecation notice goes to
+stderr, so `--json` stdout stays machine-parseable.
+
+| Before | Now |
+| --- | --- |
+| `skillroute mcp config --client codex` | `skillroute harness show codex` |
+| `skillroute mcp config --client claude-code --scope project` | `skillroute harness show claude-code --scope project` |
+| — | `skillroute harness install codex` |
+
+The `client` → `harness` rename runs through the Python API too:
+`skillroute.client_setup` re-exports the old names from
+`skillroute.harness_setup` for one release.

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -12,6 +12,7 @@ skillroute harness detect                # what is actually installed here
 skillroute harness show pi               # what setup would look like
 skillroute harness install pi --dry-run  # print, change nothing
 skillroute harness install pi --yes      # apply it
+skillroute harness doctor pi             # prove the pack still works
 ```
 
 ## Supported harnesses
@@ -160,6 +161,45 @@ Render for another platform without being on it:
 ```bash
 skillroute harness show goose --platform windows --json
 ```
+
+## Verifying a pack: `harness doctor`
+
+Manifests encode config paths for fourteen tools that each move on their own
+schedule, and a stale path fails quietly — `harness install` reports success
+while writing to a file the tool no longer reads. `doctor` is how that stays
+honest.
+
+```bash
+skillroute harness doctor                  # every pack
+skillroute harness doctor claude-code pi   # just these
+skillroute harness doctor --no-probe       # static checks only, no subprocess
+skillroute harness doctor --json           # for CI
+```
+
+Each pack gets six kinds of check:
+
+| Check | Fails when |
+| --- | --- |
+| `manifest` | the pack declares no install modes (`unverified` tier warns) |
+| `platform` | a file-writing mode has no path for the current platform |
+| `detect` | never — an absent tool warns, since you can doctor a pack you do not use |
+| `render:<mode>` | a mode no longer renders, e.g. an unresolvable placeholder |
+| `config` | the config exists but cannot be parsed |
+| `server` | the configured server command does not answer an MCP `initialize` |
+
+The `server` check is the one that cannot be faked by inspection: it runs the
+exact command the config names, sends `initialize`, and waits for a JSON-RPC
+reply. Everything else proves the pack is *describable*; this proves it *works*.
+
+Absent and unconfigured harnesses warn rather than fail, so the command exits
+non-zero only on real breakage and is usable as a CI gate:
+
+```bash
+skillroute harness doctor --no-probe --json > packs.json || echo "a pack is broken"
+```
+
+Run it on Linux and Windows too — `platform` is what catches a pack that was
+written against macOS paths only, which is exactly how v0.1 detection went wrong.
 
 ## Migrating from `skillroute mcp config`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,64 +1,99 @@
 # Roadmap
 
-This is a working roadmap for the next implementation slices.
+The 0.2 release — *"the router for skill bloat"* — ships in six independently
+mergeable stages. This file tracks their status; the stage numbers match the
+release plan and the PR titles.
 
-## Slice 1: Real Catalog Fixtures
+SKILL.md became an open standard in Dec 2025 and marketplaces followed, so
+discovery stopped being the bottleneck and judgment became it. 0.1 solved the
+judgment problem but could not reach it: it was not installable outside a git
+checkout, adding a harness cost ~7 edit sites, detection was macOS-only, and
+route traces were write-only with no caller identity. 0.2 closes those.
 
-Goal: index a broader local skill corpus and create realistic golden cases.
+| Stage | What | Status |
+| --- | --- | --- |
+| S0 | Catalog schema v2, migrations, attribution, outcomes | done |
+| S1 | Harness pack engine — 14 declarative manifests | done |
+| S2 | Distribution — PyPI, npm, Homebrew, `uvx`/`npx` configs | next |
+| S3 | Harness depth — deep packs, skills-dir sync, ACP server | not started |
+| S4 | Analytics + reports — `skillroute stats`, three renderers | not started |
+| S5 | Atlas — SSE live feed, semantic layout | not started |
+| S6 | Router intelligence — decomposition, `report_outcome`, registry gaps | not started |
 
-- Add fixture generation for a mixed skill catalog.
-- Add route cases for overlapping domains, conflicts, and complements.
-- Add eval deltas that explain rank/confidence movement.
+**Minimum coherent 0.2 if it has to ship early:** S0 + S1 + S2 + the CLI half of
+S4 — "harness packs, real distribution, and `skillroute stats`". Drop in this
+order: S6 → S5 → S4's HTML/CI renderers → S3's non-MCP install modes.
 
-## Slice 2: Backend-Aware Route Traces
+## S0 — Foundations (done)
 
-Goal: make traces explain retrieval behavior without reading raw JSON.
+Ordered, named migrations in `skillroute.migrations`; `Catalog.initialize()`
+detects the on-disk version, takes `BEGIN IMMEDIATE`, backs the file up before
+altering it, and refuses a catalog written by a newer build. Schema v2 records
+caller attribution and denormalizes ranked candidates into
+`route_trace_candidates` so analytics can use SQL. `route_outcomes`,
+`route_plans`, and `skill_projection` are created here even though S4–S6 are
+what read them, so no later stage needs a second migration on a file users keep.
 
-- Show backend hit ids, raw scores, and normalized semantic scores.
-- Mark local-only fallback when remote backend is selected but not configured.
-- Add trace comparison between two route ids.
+## S1 — Harness pack engine (done)
 
-## Slice 3: Astra Integration Contract
+Each harness is one `harnesses/<id>.toml` declaring detection, per-platform
+config paths, and install modes; the per-client quirks the old if/elif chain
+encoded became a closed set of named emitters. Adding a harness that fits an
+existing shape is a data change. Verified byte-identical to the 0.1 builder
+across all seven legacy clients before the old code was removed.
 
-Goal: make live Astra setup safer and easier to verify.
+`skillroute harness doctor` verifies a pack still matches reality — including
+running the configured server and confirming it answers an MCP `initialize`.
+See [harnesses.md](harnesses.md).
 
-- Add dry-run document preview before sync.
-- Add collection readiness checks.
-- Add small live smoke command gated by explicit credentials.
+## S2 — Distribution (next)
 
-## Slice 4: MCP Observability Tools
+The single biggest adoption unlock: nothing outside a git checkout can run
+SkillRoute today, because generated configs hardcode
+`node <repo>/mcp/build/index.js`.
 
-Goal: expose debug surfaces to agents, not only humans at the CLI.
+- Publish `skillroute` to PyPI and `@skillroute/mcp-server` to npm
+  (`PYPI_PUBLISH` / `NPM_PUBLISH` repo variables currently gate this).
+- Default generated configs to `uvx skillroute` / `npx -y @skillroute/mcp-server`,
+  with checkout paths behind `--local`.
+- Homebrew formula.
 
-- Add `skillroute.backend_status`.
-- Add `skillroute.list_traces`.
-- Add `skillroute.inspect_trace`.
+## S3 — Harness depth
 
-## Slice 4.5: Skill Atlas UI
+Deep packs for `claude-code`, `codex`, `pi`, `hermes`, `opencode` with every
+applicable mode. Skills-dir tri-mode: read-only discovery, opt-in projection,
+and `router_skill`. ACP server (`skillroute acp serve`, Python — ACP is plain
+JSON-RPC over stdio and needs no SDK). Harness attribution from the MCP
+`clientInfo` handshake.
 
-Goal: make the skill catalog explorable as a local visual graph.
+Standing risk: these tools move fast and paths drift. `harness doctor` and the
+`unverified` tier are how that stays honest.
 
-- Done: add `skillroute ui` with a local FastAPI server.
-- Done: add a React Flow/Vite Skill Atlas clustered by facets/domains.
-- Done: add read-only route previews that do not record traces.
-- Next: add metadata overlay editing and review workflows.
+## S4 — Analytics and reports
 
-## Slice 5: Router Scoring Review
+`skillroute.analytics` as pure SQL over the v2 tables, answering four question
+families: library health (which skills never win, which are near-duplicates,
+where the coverage holes are), routing quality, per-harness breakdown, and
+change over time. One report model, three renderers — terminal, self-contained
+`atlas.html`, and a GitHub Action that comments on skill-library PRs.
 
-Goal: make the hybrid score easier to tune.
+## S5 — Atlas
 
-- Extract scoring weights into a config object.
-- Add per-component eval reporting.
-- Add confidence band assertions to golden cases.
+SSE live route feed, a zero-dependency semantic layout (sparse random projection
+then power-iteration PCA, cached on the catalog fingerprint), analytics views,
+and a harness filter. The facet layout stays the default.
 
-## Slice 6: Agent Onboarding And Packaging
+## S6 — Router intelligence
 
-Goal: make local install and MCP registration smooth.
+Task decomposition into a `RoutePlan` with per-subtask steps and explicit gaps;
+`report_outcome` on MCP and ACP so agents close the loop; opt-in registry
+suggestions when decomposition finds a gap. 0.2 collects the outcome signal;
+learned routing from it is 0.3.
 
-- Done: add a one-command bootstrap for local development.
-- Done: add a prompted SkillRoute curl installer with detected-client setup.
-- Done: generate reviewed MCP setup for IBM Bob, Codex, Claude Code, Claude Desktop, VS Code, Windsurf, and Cursor.
-- Done: document current setup paths and plugin packaging direction.
-- Next: add package metadata polish.
-- Next: add a Codex plugin package with `.codex-plugin/plugin.json` and `.mcp.json`.
-- Next: add a small release checklist.
+## Out of scope for 0.2
+
+- Built-in LLM reranker (`ExternalCommandReranker` remains the seam)
+- Optional embedding-model extra
+- Indexing remote registries into the catalog — gap *suggestions* only
+- A long-lived `skillroute serve` daemon
+- Learned routing from outcome data

--- a/harnesses/amp.toml
+++ b/harnesses/amp.toml
@@ -1,0 +1,17 @@
+schema = 1
+id = "amp"
+display_name = "Amp"
+tier = "breadth"
+homepage = "https://ampcode.com/manual"
+
+[detect]
+commands = ["amp"]
+client_names = ["amp", "sourcegraph-amp"]
+paths.all = ["~/.config/amp/settings.json"]
+
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "amp_mcp_servers"
+config_path = "~/.config/amp/settings.json"
+write_path.all = "~/.config/amp/settings.json"

--- a/harnesses/claude-code.toml
+++ b/harnesses/claude-code.toml
@@ -1,0 +1,51 @@
+schema = 1
+id = "claude-code"
+display_name = "Claude Code"
+tier = "first-party"
+homepage = "https://code.claude.com/docs/en/mcp"
+
+[detect]
+commands = ["claude"]
+client_names = ["claude-code", "claude", "claude-code-*"]
+env = ["CLAUDECODE"]
+paths.all = ["~/.claude.json"]
+
+[modes.mcp]
+setup_method = "command"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "~/.claude.json"
+scopes = ["local", "project", "user"]
+default_scope = "user"
+argv = [
+    "claude", "mcp", "add",
+    "--transport", "stdio",
+    "--scope", "{scope}",
+    "--env", "SKILLROUTE_CATALOG_PATH={catalog}",
+    "--env", "SKILLROUTE_BACKEND={backend}",
+    "{server_name}",
+    "--", "{server_argv}",
+]
+write_path.all = "~/.claude.json"
+scope_paths.project = ".mcp.json"
+
+[modes.skills]
+setup_method = "dir_sync"
+dir.all = "~/.claude/skills"
+project_dir = ".claude/skills"
+discovery = ["~/.claude/skills", "~/.claude/plugins/*/skills"]
+
+[modes.router_skill]
+setup_method = "dir_sync"
+dir.all = "~/.claude/skills/skillroute"
+project_dir = ".claude/skills/skillroute"
+
+[modes.hook]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "claude_session_start_hook"
+config_path = "~/.claude/settings.json"
+write_path.all = "~/.claude/settings.json"
+scope_paths.project = ".claude/settings.json"
+scopes = ["project", "user"]
+default_scope = "project"

--- a/harnesses/claude-desktop.toml
+++ b/harnesses/claude-desktop.toml
@@ -1,0 +1,22 @@
+schema = 1
+id = "claude-desktop"
+display_name = "Claude Desktop"
+tier = "breadth"
+homepage = "https://modelcontextprotocol.io/quickstart/user"
+
+[detect]
+commands = []
+client_names = ["claude-desktop", "claude-ai"]
+paths.macos = ["~/Library/Application Support/Claude/claude_desktop_config.json"]
+paths.linux = ["~/.config/Claude/claude_desktop_config.json"]
+paths.windows = ["%APPDATA%/Claude/claude_desktop_config.json"]
+apps.macos = ["/Applications/Claude.app"]
+
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "~/Library/Application Support/Claude/claude_desktop_config.json or %APPDATA%\\Claude\\claude_desktop_config.json"
+write_path.macos = "~/Library/Application Support/Claude/claude_desktop_config.json"
+write_path.linux = "~/.config/Claude/claude_desktop_config.json"
+write_path.windows = "%APPDATA%/Claude/claude_desktop_config.json"

--- a/harnesses/codex.toml
+++ b/harnesses/codex.toml
@@ -27,7 +27,7 @@ argv = [
 write_path.all = "~/.codex/config.toml"
 
 [modes.mcp.extra]
-cwd = "{repo_root}"
+cwd = "{server_cwd}"
 startup_timeout_sec = 20
 tool_timeout_sec = 60
 

--- a/harnesses/codex.toml
+++ b/harnesses/codex.toml
@@ -1,0 +1,43 @@
+schema = 1
+id = "codex"
+display_name = "Codex"
+tier = "first-party"
+homepage = "https://developers.openai.com/codex/mcp"
+
+[detect]
+commands = ["codex"]
+client_names = ["codex", "codex-cli", "openai-codex"]
+env = ["CODEX_SANDBOX"]
+paths.all = ["~/.codex/config.toml"]
+
+# Codex is TOML-configured. SkillRoute never rewrites a user's TOML -- tomllib
+# cannot write, and hand-merging someone's config.toml is not worth the blast
+# radius -- so this installs through the CLI and only ever *prints* the snippet.
+[modes.mcp]
+setup_method = "command"
+config_format = "toml"
+emitter = "codex_toml"
+config_path = "~/.codex/config.toml"
+argv = [
+    "codex", "mcp", "add", "{server_name}",
+    "--env", "SKILLROUTE_CATALOG_PATH={catalog}",
+    "--env", "SKILLROUTE_BACKEND={backend}",
+    "--", "{server_argv}",
+]
+write_path.all = "~/.codex/config.toml"
+
+[modes.mcp.extra]
+cwd = "{repo_root}"
+startup_timeout_sec = 20
+tool_timeout_sec = 60
+
+[modes.skills]
+setup_method = "dir_sync"
+dir.all = "~/.codex/skills"
+project_dir = ".codex/skills"
+discovery = ["~/.codex/skills", "~/.codex/plugins/cache"]
+
+[modes.router_skill]
+setup_method = "dir_sync"
+dir.all = "~/.codex/skills/skillroute"
+project_dir = ".codex/skills/skillroute"

--- a/harnesses/cursor.toml
+++ b/harnesses/cursor.toml
@@ -1,0 +1,19 @@
+schema = 1
+id = "cursor"
+display_name = "Cursor"
+tier = "breadth"
+homepage = "https://cursor.com/docs/context/mcp"
+
+[detect]
+commands = ["cursor"]
+client_names = ["cursor", "cursor-*"]
+paths.all = ["~/.cursor/mcp.json"]
+apps.macos = ["/Applications/Cursor.app"]
+
+[modes.mcp]
+setup_method = "print_only"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "Cursor MCP settings"
+write_path.all = "~/.cursor/mcp.json"
+notes = ["Cursor setup is snippet-only until a stable official write target is confirmed."]

--- a/harnesses/gemini-cli.toml
+++ b/harnesses/gemini-cli.toml
@@ -1,0 +1,22 @@
+schema = 1
+id = "gemini-cli"
+display_name = "Gemini CLI"
+tier = "breadth"
+homepage = "https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html"
+
+[detect]
+commands = ["gemini"]
+client_names = ["gemini-cli", "gemini"]
+paths.all = ["~/.gemini/settings.json"]
+
+# Gemini CLI uses the same top-level mcpServers shape as Claude Code, so this
+# whole harness is pure data -- no new emitter.
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "~/.gemini/settings.json"
+write_path.all = "~/.gemini/settings.json"
+scope_paths.project = ".gemini/settings.json"
+scopes = ["user", "project"]
+default_scope = "user"

--- a/harnesses/goose.toml
+++ b/harnesses/goose.toml
@@ -1,0 +1,29 @@
+schema = 1
+id = "goose"
+display_name = "Goose"
+tier = "breadth"
+homepage = "https://block.github.io/goose/docs/getting-started/using-extensions"
+
+[detect]
+commands = ["goose"]
+client_names = ["goose", "goose-cli"]
+paths.macos = ["~/.config/goose/config.yaml"]
+paths.linux = ["~/.config/goose/config.yaml"]
+paths.windows = ["%APPDATA%/Block/goose/config/config.yaml"]
+
+# Goose is YAML-configured, so this prints rather than merges. Goose calls MCP
+# servers "extensions" and keys them by a normalized identifier.
+[modes.mcp]
+setup_method = "print_only"
+config_format = "yaml"
+emitter = "yaml_map"
+config_path = "~/.config/goose/config.yaml"
+write_path.macos = "~/.config/goose/config.yaml"
+write_path.linux = "~/.config/goose/config.yaml"
+write_path.windows = "%APPDATA%/Block/goose/config/config.yaml"
+notes = [
+    "Add the printed block under `extensions:` in the Goose config, or run `goose configure`.",
+]
+
+[modes.mcp.extra]
+container = "extensions"

--- a/harnesses/hermes.toml
+++ b/harnesses/hermes.toml
@@ -1,0 +1,50 @@
+schema = 1
+id = "hermes"
+display_name = "Hermes Agent"
+tier = "first-party"
+homepage = "https://hermes-agent.nousresearch.com/docs"
+
+[detect]
+commands = ["hermes"]
+client_names = ["hermes", "hermes-agent"]
+paths.all = ["~/.hermes/config.yaml"]
+
+# Hermes is YAML-configured and SkillRoute carries no YAML dependency, so the
+# MCP entry is printed rather than merged. The yaml_map emitter renders the
+# snippet; it never writes the user's file.
+[modes.mcp]
+setup_method = "print_only"
+config_format = "yaml"
+emitter = "yaml_map"
+config_path = "~/.hermes/config.yaml"
+write_path.all = "~/.hermes/config.yaml"
+notes = [
+    "Add the printed block under `mcp_servers:` in ~/.hermes/config.yaml.",
+    "Hermes keys mcp_servers by server name, not as a list.",
+]
+
+[modes.mcp.extra]
+container = "mcp_servers"
+
+[modes.acp]
+setup_method = "print_only"
+config_format = "yaml"
+emitter = "yaml_map"
+config_path = "~/.hermes/config.yaml"
+notes = ["Hermes speaks ACP, so SkillRoute can attach as a routing-advisor agent."]
+
+[modes.acp.extra]
+container = "agents"
+
+[modes.skills]
+setup_method = "dir_sync"
+dir.all = "~/.hermes/skills"
+discovery = ["~/.hermes/skills"]
+# Hermes reads extra skill directories from external_dirs, so registration
+# beats copying: no duplication and no sync drift.
+register_in.path = "~/.hermes/config.yaml"
+register_in.key = "external_dirs"
+
+[modes.router_skill]
+setup_method = "dir_sync"
+dir.all = "~/.hermes/skills/skillroute"

--- a/harnesses/ibm-bob.toml
+++ b/harnesses/ibm-bob.toml
@@ -18,5 +18,5 @@ config_path = "~/.bob/mcp.json or .bob/mcp.json"
 write_path.all = "~/.bob/mcp.json"
 
 [modes.mcp.extra]
-cwd = "{repo_root}"
+cwd = "{server_cwd}"
 disabled = false

--- a/harnesses/ibm-bob.toml
+++ b/harnesses/ibm-bob.toml
@@ -1,0 +1,22 @@
+schema = 1
+id = "ibm-bob"
+display_name = "IBM Bob"
+tier = "breadth"
+homepage = "https://www.ibm.com/products/bob"
+
+[detect]
+commands = []
+client_names = ["ibm-bob", "bob"]
+paths.all = ["~/.bob/mcp.json"]
+apps.macos = ["/Applications/IBM Bob.app"]
+
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "~/.bob/mcp.json or .bob/mcp.json"
+write_path.all = "~/.bob/mcp.json"
+
+[modes.mcp.extra]
+cwd = "{repo_root}"
+disabled = false

--- a/harnesses/opencode.toml
+++ b/harnesses/opencode.toml
@@ -1,0 +1,33 @@
+schema = 1
+id = "opencode"
+display_name = "OpenCode"
+tier = "first-party"
+homepage = "https://opencode.ai/docs/mcp-servers"
+
+[detect]
+commands = ["opencode"]
+client_names = ["opencode"]
+paths.all = ["~/.config/opencode/opencode.json"]
+
+# OpenCode nests servers under "mcp" with an explicit local/remote type, rather
+# than the "mcpServers" shape everyone else uses.
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "opencode_mcp"
+config_path = "~/.config/opencode/opencode.json"
+write_path.all = "~/.config/opencode/opencode.json"
+scope_paths.project = "opencode.json"
+scopes = ["user", "project"]
+default_scope = "user"
+
+[modes.skills]
+setup_method = "dir_sync"
+dir.all = "~/.config/opencode/skills"
+project_dir = ".opencode/skills"
+discovery = ["~/.config/opencode/skills", ".opencode/skills"]
+
+[modes.router_skill]
+setup_method = "dir_sync"
+dir.all = "~/.config/opencode/skills/skillroute"
+project_dir = ".opencode/skills/skillroute"

--- a/harnesses/pi.toml
+++ b/harnesses/pi.toml
@@ -1,0 +1,41 @@
+schema = 1
+id = "pi"
+display_name = "Pi"
+tier = "first-party"
+homepage = "https://pi.dev"
+
+[detect]
+commands = ["pi"]
+client_names = ["pi", "pi-coding-agent"]
+paths.all = ["~/.pi/agent/settings.json"]
+
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "~/.pi/agent/mcp.json"
+write_path.all = "~/.pi/agent/mcp.json"
+scope_paths.project = ".pi/mcp.json"
+scopes = ["user", "project"]
+default_scope = "user"
+
+[modes.skills]
+setup_method = "dir_sync"
+dir.all = "~/.pi/agent/skills"
+project_dir = ".pi/skills"
+discovery = ["~/.pi/agent/skills", ".pi/skills"]
+# Pi's settings declare where skills load from, so SkillRoute can register a
+# directory instead of copying bundles into Pi's own.
+register_in.path = "~/.pi/agent/settings.json"
+register_in.key = "skills"
+
+[modes.extension]
+setup_method = "package"
+config_path = "~/.pi/agent/extensions"
+write_path.all = "~/.pi/agent/extensions"
+notes = ["Pi extensions are TypeScript files or directories under the extensions path."]
+
+[modes.router_skill]
+setup_method = "dir_sync"
+dir.all = "~/.pi/agent/skills/skillroute"
+project_dir = ".pi/skills/skillroute"

--- a/harnesses/vscode.toml
+++ b/harnesses/vscode.toml
@@ -1,0 +1,19 @@
+schema = 1
+id = "vscode"
+display_name = "VS Code"
+tier = "breadth"
+homepage = "https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+
+[detect]
+commands = ["code", "code-insiders"]
+client_names = ["vscode", "visual-studio-code"]
+env = ["VSCODE_PID"]
+
+# VS Code is the one harness that uses a top-level "servers" key rather than
+# "mcpServers", and embeds the server name inside the object it is handed.
+[modes.mcp]
+setup_method = "command"
+config_format = "json"
+emitter = "vscode_servers"
+config_path = "VS Code user profile mcp.json"
+argv = ["code", "--add-mcp", "{server_json}"]

--- a/harnesses/windsurf.toml
+++ b/harnesses/windsurf.toml
@@ -1,0 +1,18 @@
+schema = 1
+id = "windsurf"
+display_name = "Windsurf"
+tier = "breadth"
+homepage = "https://docs.windsurf.com/windsurf/cascade/mcp"
+
+[detect]
+commands = ["windsurf"]
+client_names = ["windsurf", "codeium"]
+paths.all = ["~/.codeium/windsurf/mcp_config.json"]
+apps.macos = ["/Applications/Windsurf.app"]
+
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "mcp_servers"
+config_path = "~/.codeium/windsurf/mcp_config.json"
+write_path.all = "~/.codeium/windsurf/mcp_config.json"

--- a/harnesses/zed.toml
+++ b/harnesses/zed.toml
@@ -1,0 +1,29 @@
+schema = 1
+id = "zed"
+display_name = "Zed"
+tier = "breadth"
+homepage = "https://zed.dev/docs/ai/mcp"
+
+[detect]
+commands = ["zed"]
+client_names = ["zed"]
+paths.macos = ["~/.config/zed/settings.json"]
+paths.linux = ["~/.config/zed/settings.json"]
+paths.windows = ["%APPDATA%/Zed/settings.json"]
+apps.macos = ["/Applications/Zed.app"]
+
+[modes.mcp]
+setup_method = "json_merge"
+config_format = "json"
+emitter = "zed_context_servers"
+config_path = "~/.config/zed/settings.json"
+write_path.macos = "~/.config/zed/settings.json"
+write_path.linux = "~/.config/zed/settings.json"
+write_path.windows = "%APPDATA%/Zed/settings.json"
+
+[modes.acp]
+setup_method = "print_only"
+config_format = "json"
+emitter = "zed_context_servers"
+config_path = "~/.config/zed/settings.json"
+notes = ["Zed speaks ACP natively; SkillRoute attaches as a routing-advisor agent."]

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,8 +1,13 @@
-"""Hatch build hook that ships the built web UI inside distributions.
+"""Hatch build hook that ships bundled assets inside distributions.
 
-Wheels get the assets at ``skillroute/_web`` so ``skillroute ui`` works from a
-plain ``pip install``; sdists keep them at ``web/dist`` so wheels built from an
-sdist do not need node.
+Two things travel with the package:
+
+* the built web UI -- wheels get it at ``skillroute/_web`` so ``skillroute ui``
+  works from a plain ``pip install``; sdists keep it at ``web/dist`` so wheels
+  built from an sdist do not need node.
+* the harness manifests -- wheels get them at ``skillroute/_harnesses``, which
+  is where ``harnesses.default_manifest_root()`` looks first. Without this a
+  pip-installed SkillRoute would know about no harnesses at all.
 """
 
 from __future__ import annotations
@@ -25,8 +30,16 @@ class WebAssetsBuildHook(BuildHookInterface):
         dist = web_dir / "dist"
         if not (dist / "index.html").exists():
             self._build_web_assets(web_dir)
+        force_include = build_data.setdefault("force_include", {})
         target = "skillroute/_web" if self.target_name == "wheel" else "web/dist"
-        build_data.setdefault("force_include", {})[str(dist)] = target
+        force_include[str(dist)] = target
+
+        harnesses = Path(self.root) / "harnesses"
+        if not any(harnesses.glob("*.toml")):
+            raise RuntimeError(f"No harness manifests found in {harnesses}")
+        force_include[str(harnesses)] = (
+            "skillroute/_harnesses" if self.target_name == "wheel" else "harnesses"
+        )
 
     def _build_web_assets(self, web_dir: Path) -> None:
         npm = shutil.which("npm")

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skillroute/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skillroute/mcp-server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillroute/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SkillRoute MCP stdio server",
   "license": "MIT",
   "author": "Eric Hare",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skillroute"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local-first skill catalog and router for agent builders"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/skillroute/attribution.py
+++ b/src/skillroute/attribution.py
@@ -1,0 +1,82 @@
+"""Who asked for a route, and over which surface.
+
+v0.1 recorded nothing about the caller, so every trace looked alike and
+per-harness quality was unanswerable. Attribution is resolved from whatever the
+calling surface can offer, best source first, and is always allowed to come back
+empty -- an unknown caller is normal (a hand-written MCP config, a direct library
+call) and must never be an error.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Surfaces a route can arrive through. Recorded on every trace so analytics can
+# separate "an agent asked" from "a human ran the CLI" from "an eval did it".
+SURFACES = ("cli", "mcp", "acp", "ui", "eval", "bridge")
+
+HARNESS_ENV_VAR = "SKILLROUTE_HARNESS"
+HARNESS_VERSION_ENV_VAR = "SKILLROUTE_HARNESS_VERSION"
+
+
+@dataclass(frozen=True, slots=True)
+class Attribution:
+    harness_id: str | None = None
+    harness_version: str | None = None
+    surface: str = "cli"
+
+    def to_json(self) -> dict[str, str | None]:
+        return {
+            "harness_id": self.harness_id,
+            "harness_version": self.harness_version,
+            "surface": self.surface,
+        }
+
+
+def resolve_attribution(
+    *,
+    explicit: str | None = None,
+    explicit_version: str | None = None,
+    client_name: str | None = None,
+    surface: str = "cli",
+    client_name_lookup: object | None = None,
+    environ: dict[str, str] | None = None,
+) -> Attribution:
+    """Resolve the calling harness, most trustworthy source first.
+
+    1. ``explicit`` -- the caller told us outright (bridge payload, ``--harness``).
+    2. ``client_name`` -- the MCP ``initialize`` handshake's ``clientInfo.name``,
+       mapped to a harness id through the manifests.
+    3. ``SKILLROUTE_HARNESS`` -- stamped into generated configs at install time,
+       which covers ACP and direct CLI use where no handshake exists.
+
+    ``client_name_lookup`` is injected rather than imported so this module stays
+    free of a dependency on the harness manifests (and so tests can drive it
+    without loading them).
+    """
+    env = os.environ if environ is None else environ
+    resolved_surface = surface if surface in SURFACES else "cli"
+
+    harness_id = _clean(explicit)
+    version = _clean(explicit_version)
+
+    if harness_id is None and client_name and callable(client_name_lookup):
+        harness_id = _clean(client_name_lookup(client_name))
+
+    if harness_id is None:
+        harness_id = _clean(env.get(HARNESS_ENV_VAR))
+
+    if version is None:
+        version = _clean(env.get(HARNESS_VERSION_ENV_VAR))
+
+    return Attribution(
+        harness_id=harness_id, harness_version=version, surface=resolved_surface
+    )
+
+
+def _clean(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/src/skillroute/catalog.py
+++ b/src/skillroute/catalog.py
@@ -1,15 +1,27 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
+import shutil
 import sqlite3
 import sys
+import uuid
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+from skillroute.attribution import Attribution
 from skillroute.backends import LocalTokenBackend
+from skillroute.migrations import (
+    V2_INDEXES_SQL,
+    V2_TABLES_SQL,
+    V2_TRACE_COLUMNS,
+    CatalogVersionError,
+    apply_pending,
+    detect_schema_version,
+)
 from skillroute.models import (
     RouteResponse,
     SkillExcerpt,
@@ -21,8 +33,108 @@ from skillroute.models import (
 from skillroute.overlays import load_overlays, overlay_for_skill
 from skillroute.parser import discover_skill_files, parse_frontmatter, parse_skill_bundle
 
-SCHEMA_VERSION = 1
-MAX_ROUTE_TRACES = 1000
+SCHEMA_VERSION = 2
+
+# Raw traces are capped; the daily rollup is not. v0.1 kept 1000 rows, which is
+# a few days of one active harness -- far too short a horizon for "clarification
+# rate over time" to mean anything. Aggregates in route_trace_daily survive
+# pruning, so the raw cap only bounds how far back full detail is available.
+DEFAULT_MAX_ROUTE_TRACES = 20_000
+# Module-level so tests (and anyone embedding SkillRoute) can override it;
+# max_route_traces() layers the SKILLROUTE_MAX_TRACES env var on top.
+MAX_ROUTE_TRACES = DEFAULT_MAX_ROUTE_TRACES
+
+# Pruning runs an OFFSET subquery that is no longer free at 20k rows, so amortize
+# it instead of paying on every single insert.
+PRUNE_INTERVAL = 64
+
+# The v1 core. A fresh catalog gets this plus the v2 additions imported from
+# migrations, so the "create current shape" and "migrate up to it" paths share
+# the v2 DDL verbatim instead of drifting apart. tests/test_migrations.py asserts
+# a fresh database and a migrated one end up structurally identical.
+BASE_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS skills (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    skill_path TEXT NOT NULL,
+    bundle_path TEXT NOT NULL,
+    root_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    metadata_json TEXT NOT NULL,
+    tags_json TEXT NOT NULL,
+    facets_json TEXT NOT NULL,
+    references_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS excerpts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    text TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS relationships (
+    from_skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    to_ref TEXT NOT NULL,
+    PRIMARY KEY (from_skill_id, type, to_ref)
+);
+
+CREATE TABLE IF NOT EXISTS backend_index_refs (
+    skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    backend TEXT NOT NULL,
+    ref TEXT NOT NULL,
+    status TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (skill_id, backend)
+);
+
+CREATE TABLE IF NOT EXISTS route_traces (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_json TEXT NOT NULL,
+    response_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP{v2_trace_columns}
+);
+
+CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
+CREATE INDEX IF NOT EXISTS idx_skills_root ON skills(root_path);
+CREATE INDEX IF NOT EXISTS idx_excerpts_skill ON excerpts(skill_id);
+CREATE INDEX IF NOT EXISTS idx_backend_refs_skill ON backend_index_refs(skill_id);
+"""
+
+CREATE_SCHEMA_SQL = (
+    BASE_SCHEMA_SQL.format(
+        v2_trace_columns="".join(
+            f",\n    {column} {column_type}" for column, column_type in V2_TRACE_COLUMNS
+        )
+    )
+    + V2_TABLES_SQL
+    + V2_INDEXES_SQL
+)
+
+
+def max_route_traces() -> int:
+    """Raw-trace retention. ``SKILLROUTE_MAX_TRACES=0`` disables pruning."""
+    configured = os.environ.get("SKILLROUTE_MAX_TRACES")
+    if configured:
+        try:
+            return max(0, int(configured))
+        except ValueError:
+            print(
+                f"skillroute: ignoring invalid SKILLROUTE_MAX_TRACES={configured!r}",
+                file=sys.stderr,
+            )
+    return MAX_ROUTE_TRACES
 
 
 def default_catalog_path(base: Path | None = None) -> Path:
@@ -58,74 +170,65 @@ class Catalog:
             connection.close()
 
     def initialize(self) -> None:
+        """Create, migrate, or accept the catalog on disk.
+
+        Three paths, decided by :func:`detect_schema_version`:
+
+        * fresh (no tables) -- create the current shape directly and stamp it;
+        * older -- back the file up, then apply migrations in order;
+        * newer -- refuse, rather than corrupt a catalog this build cannot read.
+
+        ``BEGIN IMMEDIATE`` takes the write lock up front so a concurrent
+        ``skillroute index`` and UI server cannot both try to migrate. The
+        existing ``busy_timeout`` makes the loser wait instead of failing.
+        """
         if self._initialized:
             return
-        with self._session() as connection:
-            connection.executescript(
-                """
-                CREATE TABLE IF NOT EXISTS schema_version (
-                    version INTEGER NOT NULL
-                );
-
-                CREATE TABLE IF NOT EXISTS skills (
-                    id TEXT PRIMARY KEY,
-                    name TEXT NOT NULL,
-                    description TEXT NOT NULL,
-                    skill_path TEXT NOT NULL,
-                    bundle_path TEXT NOT NULL,
-                    root_path TEXT NOT NULL,
-                    content_hash TEXT NOT NULL,
-                    metadata_json TEXT NOT NULL,
-                    tags_json TEXT NOT NULL,
-                    facets_json TEXT NOT NULL,
-                    references_json TEXT NOT NULL,
-                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                );
-
-                CREATE TABLE IF NOT EXISTS excerpts (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
-                    kind TEXT NOT NULL,
-                    text TEXT NOT NULL,
-                    source_path TEXT NOT NULL,
-                    start_line INTEGER NOT NULL,
-                    end_line INTEGER NOT NULL
-                );
-
-                CREATE TABLE IF NOT EXISTS relationships (
-                    from_skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
-                    type TEXT NOT NULL,
-                    to_ref TEXT NOT NULL,
-                    PRIMARY KEY (from_skill_id, type, to_ref)
-                );
-
-                CREATE TABLE IF NOT EXISTS backend_index_refs (
-                    skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
-                    backend TEXT NOT NULL,
-                    ref TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    PRIMARY KEY (skill_id, backend)
-                );
-
-                CREATE TABLE IF NOT EXISTS route_traces (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    request_json TEXT NOT NULL,
-                    response_json TEXT NOT NULL,
-                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
-                CREATE INDEX IF NOT EXISTS idx_skills_root ON skills(root_path);
-                CREATE INDEX IF NOT EXISTS idx_excerpts_skill ON excerpts(skill_id);
-                CREATE INDEX IF NOT EXISTS idx_backend_refs_skill ON backend_index_refs(skill_id);
-                """
-            )
-            existing = connection.execute("SELECT COUNT(*) FROM schema_version").fetchone()[0]
-            if not existing:
-                connection.execute("INSERT INTO schema_version(version) VALUES (?)", (SCHEMA_VERSION,))
+        connection = self.connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            current = detect_schema_version(connection)
+            if current > SCHEMA_VERSION:
+                raise CatalogVersionError(
+                    f"Catalog {self.path} is schema v{current}, but this SkillRoute "
+                    f"understands up to v{SCHEMA_VERSION}. Upgrade SkillRoute, or point "
+                    "--catalog / SKILLROUTE_CATALOG_PATH at a different file."
+                )
+            if current == 0:
+                connection.executescript(CREATE_SCHEMA_SQL)
+            elif current < SCHEMA_VERSION:
+                self._backup_before_migration(current)
+                current = apply_pending(connection, current)
+            self._stamp_version(connection, SCHEMA_VERSION)
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
         self._initialized = True
+
+    def _backup_before_migration(self, from_version: int) -> Path:
+        """Copy the catalog aside before altering it.
+
+        Same reasoning and naming shape as ``merge_json_config``'s config
+        backups: a schema upgrade is the highest-blast-radius thing SkillRoute
+        does to a file the user owns, so leave them a way back.
+        """
+        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d%H%M%S")
+        backup_path = self.path.with_name(f"{self.path.name}.bak-v{from_version}-{timestamp}")
+        shutil.copy2(self.path, backup_path)
+        print(f"skillroute: backed up catalog to {backup_path}", file=sys.stderr)
+        return backup_path
+
+    @staticmethod
+    def _stamp_version(connection: sqlite3.Connection, version: int) -> None:
+        # Replace rather than append: the v1 code only inserted when the table
+        # was empty, which is why reads had to ORDER BY version DESC.
+        connection.execute("DELETE FROM schema_version")
+        connection.execute("INSERT INTO schema_version(version) VALUES (?)", (version,))
+        # Mirrored so external tooling can read the version without a query.
+        connection.execute(f"PRAGMA user_version = {int(version)}")
 
     def schema_version(self) -> int | None:
         self.initialize()
@@ -258,23 +361,174 @@ class Catalog:
     def find_by_name_or_id(self, skill_ref: str) -> SkillRecord | None:
         return self.get_skill(skill_ref)
 
-    def record_route_trace(self, request: dict[str, Any], response: RouteResponse) -> None:
+    def record_route_trace(
+        self,
+        request: dict[str, Any],
+        response: RouteResponse,
+        *,
+        attribution: Attribution | None = None,
+        plan_id: str | None = None,
+        subtask_index: int | None = None,
+        subtask_text: str | None = None,
+        catalog_fingerprint: str | None = None,
+        weights: dict[str, float] | None = None,
+    ) -> str:
+        """Persist one routing call and return its stable ``trace_uid``.
+
+        The JSON blobs stay (they are the full record, and the UI reads them),
+        but the fields analytics groups and filters on are promoted to columns
+        and to ``route_trace_candidates``. Reported outcomes reference the
+        returned uid, which survives trace pruning even though the row does not.
+        """
         self.initialize()
+        trace_uid = uuid.uuid4().hex
+        attribution = attribution or Attribution()
+        harness_id = attribution.harness_id
+        harness_version = attribution.harness_version
+        surface = attribution.surface
+        confidences = [candidate.confidence for candidate in response.candidates]
+        top = response.candidates[0] if response.candidates else None
         with self._session() as connection:
-            connection.execute(
-                "INSERT INTO route_traces (request_json, response_json) VALUES (?, ?)",
-                (json.dumps(request, sort_keys=True), json.dumps(to_jsonable(response), sort_keys=True)),
-            )
-            # Bound unbounded growth: keep only the most recent traces.
-            connection.execute(
+            cursor = connection.execute(
                 """
-                DELETE FROM route_traces
-                WHERE id <= (
-                    SELECT id FROM route_traces ORDER BY id DESC LIMIT 1 OFFSET ?
+                INSERT INTO route_traces (
+                    request_json, response_json, trace_uid, harness_id, harness_version,
+                    surface, request_text, backend, repo_path, top_skill_id, top_confidence,
+                    second_confidence, candidate_count, clarification_needed,
+                    plan_id, subtask_index, subtask_text, catalog_fingerprint, weights_json
                 )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (MAX_ROUTE_TRACES,),
+                (
+                    json.dumps(request, sort_keys=True),
+                    json.dumps(to_jsonable(response), sort_keys=True),
+                    trace_uid,
+                    harness_id,
+                    harness_version,
+                    surface,
+                    response.request,
+                    request.get("backend"),
+                    request.get("repo"),
+                    top.skill_id if top else None,
+                    confidences[0] if confidences else None,
+                    confidences[1] if len(confidences) > 1 else None,
+                    len(response.candidates),
+                    int(bool(response.clarification_needed)),
+                    plan_id,
+                    subtask_index,
+                    subtask_text,
+                    catalog_fingerprint,
+                    json.dumps(weights, sort_keys=True) if weights else None,
+                ),
             )
+            trace_id = int(cursor.lastrowid or 0)
+            for position, candidate in enumerate(response.candidates, start=1):
+                breakdown = candidate.score_breakdown
+                connection.execute(
+                    """
+                    INSERT INTO route_trace_candidates (
+                        trace_id, position, skill_id, content_hash, name, confidence,
+                        lexical, semantic, repo_context, graph, total
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        trace_id,
+                        position,
+                        candidate.skill_id,
+                        candidate.content_hash,
+                        candidate.name,
+                        candidate.confidence,
+                        breakdown.lexical,
+                        breakdown.semantic,
+                        breakdown.repo_context,
+                        breakdown.graph,
+                        breakdown.total,
+                    ),
+                )
+            self._bump_daily_rollup(
+                connection,
+                harness_id=harness_id or "",
+                confidence=confidences[0] if confidences else 0.0,
+                clarification=bool(response.clarification_needed),
+            )
+            self._prune_route_traces(connection, trace_id)
+        return trace_uid
+
+    @staticmethod
+    def _bump_daily_rollup(
+        connection: sqlite3.Connection,
+        *,
+        harness_id: str,
+        confidence: float,
+        clarification: bool,
+    ) -> None:
+        """Fold one route into today's aggregate.
+
+        This is what makes "change over time" survive the raw-trace cap: the
+        rollup is never pruned, so a year-old day still reports its route count,
+        clarification rate, and mean confidence long after the traces are gone.
+        """
+        bucket = str(min(9, max(0, int(confidence * 10))))
+        connection.execute(
+            """
+            INSERT INTO route_trace_daily (
+                day, harness_id, route_count, clarification_count,
+                confidence_sum, confidence_min, confidence_max, histogram_json
+            )
+            VALUES (DATE('now'), ?, 1, ?, ?, ?, ?, '{}')
+            ON CONFLICT(day, harness_id) DO UPDATE SET
+                route_count = route_count + 1,
+                clarification_count = clarification_count + excluded.clarification_count,
+                confidence_sum = confidence_sum + excluded.confidence_sum,
+                confidence_min = MIN(confidence_min, excluded.confidence_min),
+                confidence_max = MAX(confidence_max, excluded.confidence_max)
+            """,
+            (harness_id, int(clarification), confidence, confidence, confidence),
+        )
+        # The histogram merges in Python: SQLite has no JSON object merge, and
+        # json_patch() is not available on every bundled build. The row above
+        # always starts it empty so this read-modify-write is the only place
+        # buckets are ever incremented.
+        row = connection.execute(
+            "SELECT histogram_json FROM route_trace_daily WHERE day = DATE('now') AND harness_id = ?",
+            (harness_id,),
+        ).fetchone()
+        if row is None:
+            return
+        try:
+            histogram = json.loads(row["histogram_json"])
+            if not isinstance(histogram, dict):
+                histogram = {}
+        except (json.JSONDecodeError, TypeError):
+            histogram = {}
+        histogram[bucket] = int(histogram.get(bucket, 0)) + 1
+        connection.execute(
+            "UPDATE route_trace_daily SET histogram_json = ? WHERE day = DATE('now') AND harness_id = ?",
+            (json.dumps(histogram, sort_keys=True), harness_id),
+        )
+
+    @staticmethod
+    def _prune_route_traces(connection: sqlite3.Connection, trace_id: int) -> None:
+        """Bound raw-trace growth, amortized.
+
+        The OFFSET subquery is not free at 20k rows, so it runs once every
+        ``PRUNE_INTERVAL`` inserts rather than on every one. The table can
+        therefore sit up to ``PRUNE_INTERVAL`` rows above the cap between
+        prunes, which is fine -- readers always pass their own LIMIT.
+        """
+        cap = max_route_traces()
+        if cap <= 0 or PRUNE_INTERVAL <= 0 or trace_id % PRUNE_INTERVAL != 0:
+            return
+        connection.execute(
+            """
+            DELETE FROM route_traces
+            WHERE id <= (
+                SELECT id FROM route_traces ORDER BY id DESC LIMIT 1 OFFSET ?
+            )
+            """,
+            (cap,),
+        )
 
     def list_route_traces(self, limit: int = 20) -> list[dict[str, Any]]:
         self.initialize()
@@ -302,6 +556,59 @@ class Catalog:
                 (trace_id,),
             ).fetchone()
             return route_trace_detail(row) if row else None
+
+    def record_outcome(
+        self,
+        trace_uid: str,
+        *,
+        skill_id: str | None = None,
+        used: bool = True,
+        helpful: bool | None = None,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Record what an agent actually did with a route.
+
+        Closes the loop that makes precision measurable rather than assumed.
+        ``rank_used`` is resolved here rather than trusted from the caller: the
+        agent knows which skill it used, but only the catalog knows what rank
+        that skill was offered at.
+        """
+        self.initialize()
+        with self._session() as connection:
+            row = connection.execute(
+                "SELECT id, harness_id FROM route_traces WHERE trace_uid = ?",
+                (trace_uid,),
+            ).fetchone()
+            if row is None:
+                return {"recorded": False, "reason": f"unknown trace_uid: {trace_uid}"}
+            rank_used: int | None = None
+            if skill_id:
+                rank_row = connection.execute(
+                    """
+                    SELECT position FROM route_trace_candidates
+                    WHERE trace_id = ? AND skill_id = ?
+                    """,
+                    (row["id"], skill_id),
+                ).fetchone()
+                rank_used = int(rank_row["position"]) if rank_row else None
+            connection.execute(
+                """
+                INSERT INTO route_outcomes (
+                    trace_uid, skill_id, used, helpful, rank_used, harness_id, note
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    trace_uid,
+                    skill_id,
+                    int(bool(used)),
+                    None if helpful is None else int(helpful),
+                    rank_used,
+                    row["harness_id"],
+                    note,
+                ),
+            )
+        return {"recorded": True, "trace_uid": trace_uid, "rank_used": rank_used}
 
     def save_backend_ref(self, skill_id: str, backend: str, ref: str, status: str) -> None:
         self.initialize()

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -30,6 +30,8 @@ from skillroute.harness_doctor import (
     run_doctor,
 )
 from skillroute.harness_render import (
+    DEFAULT_SERVER_SOURCE,
+    SERVER_SOURCES,
     build_harness_setup,
     default_repo_root,
     render_harness_setup,
@@ -301,6 +303,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_backend_argument(harness_show_parser)
     harness_show_parser.add_argument("--json", action="store_true", dest="as_json")
+    harness_show_parser.add_argument(
+        "--server-source",
+        choices=SERVER_SOURCES,
+        default=DEFAULT_SERVER_SOURCE,
+        help="Point the config at a built checkout (local) or the published package (npx)",
+    )
     harness_show_parser.set_defaults(func=cmd_harness_show)
 
     harness_install_parser = harness_subparsers.add_parser(
@@ -316,6 +324,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run", action="store_true", help="Print what would be done, change nothing"
     )
     harness_install_parser.add_argument("--yes", action="store_true")
+    harness_install_parser.add_argument(
+        "--server-source",
+        choices=SERVER_SOURCES,
+        default=DEFAULT_SERVER_SOURCE,
+        help="Point the config at a built checkout (local) or the published package (npx)",
+    )
     harness_install_parser.set_defaults(func=cmd_harness_install)
 
     harness_doctor_parser = harness_subparsers.add_parser(
@@ -755,6 +769,7 @@ def cmd_harness_show(args: argparse.Namespace) -> None:
         server_name=args.server_name,
         scope=args.scope,
         platform=args.platform,
+        server_source=args.server_source,
     )
     if args.as_json:
         print_json(payload)
@@ -772,6 +787,7 @@ def cmd_harness_install(args: argparse.Namespace) -> None:
         backend=args.backend,
         server_name=args.server_name,
         scope=args.scope,
+        server_source=args.server_source,
     )
     if args.dry_run:
         print(render_harness_setup(payload))

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -5,6 +5,7 @@ import json
 import sys
 from collections.abc import Callable
 from contextlib import nullcontext
+from dataclasses import asdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -22,6 +23,17 @@ from skillroute.backends import (
 from skillroute.catalog import Catalog, default_catalog_path
 from skillroute.dogfood import discover_default_skill_roots, index_default_skill_roots
 from skillroute.evals import run_golden_routes
+from skillroute.harness_render import (
+    build_harness_setup,
+    default_repo_root,
+    render_harness_setup,
+)
+from skillroute.harness_setup import (
+    apply_harness_setup,
+    detect_harnesses,
+    print_detection_summary,
+)
+from skillroute.harnesses import PLATFORMS, harness_ids, load_manifests
 from skillroute.mcp_setup import (
     CLAUDE_SCOPE_CHOICES,
     MCP_CLIENT_CHOICES,
@@ -36,6 +48,10 @@ from skillroute.metadata import (
 from skillroute.models import to_jsonable
 from skillroute.routing import Router
 from skillroute.tuning import tune_weights
+
+# Resolved once at import so argparse `choices` stay in sync with the manifests
+# on disk without every subparser reloading them.
+HARNESS_IDS = harness_ids()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -247,6 +263,54 @@ def build_parser() -> argparse.ArgumentParser:
     )
     mcp_config_parser.add_argument("--json", action="store_true", dest="as_json")
     mcp_config_parser.set_defaults(func=cmd_mcp_config)
+
+    harness_parser = subparsers.add_parser(
+        "harness", help="Inspect and configure agent harnesses"
+    )
+    harness_subparsers = harness_parser.add_subparsers(dest="harness_command", required=True)
+
+    harness_list_parser = harness_subparsers.add_parser(
+        "list", help="List every harness SkillRoute knows about"
+    )
+    harness_list_parser.add_argument("--mode", default=None, help="Only harnesses supporting MODE")
+    harness_list_parser.add_argument("--json", action="store_true", dest="as_json")
+    harness_list_parser.set_defaults(func=cmd_harness_list)
+
+    harness_detect_parser = harness_subparsers.add_parser(
+        "detect", help="Detect which harnesses are installed"
+    )
+    harness_detect_parser.add_argument("--json", action="store_true", dest="as_json")
+    harness_detect_parser.set_defaults(func=cmd_harness_detect)
+
+    harness_show_parser = harness_subparsers.add_parser(
+        "show", help="Show the setup SkillRoute would apply for one harness"
+    )
+    harness_show_parser.add_argument("harness", choices=HARNESS_IDS)
+    harness_show_parser.add_argument("--mode", default="mcp")
+    harness_show_parser.add_argument("--scope", default=None)
+    harness_show_parser.add_argument("--repo-root", type=Path, default=None)
+    harness_show_parser.add_argument("--server-name", default="skillroute")
+    harness_show_parser.add_argument(
+        "--platform", choices=PLATFORMS, default=None, help="Render for another platform"
+    )
+    add_backend_argument(harness_show_parser)
+    harness_show_parser.add_argument("--json", action="store_true", dest="as_json")
+    harness_show_parser.set_defaults(func=cmd_harness_show)
+
+    harness_install_parser = harness_subparsers.add_parser(
+        "install", help="Configure a harness to use SkillRoute"
+    )
+    harness_install_parser.add_argument("harness", choices=HARNESS_IDS)
+    harness_install_parser.add_argument("--mode", default="mcp")
+    harness_install_parser.add_argument("--scope", default=None)
+    harness_install_parser.add_argument("--repo-root", type=Path, default=None)
+    harness_install_parser.add_argument("--server-name", default="skillroute")
+    add_backend_argument(harness_install_parser)
+    harness_install_parser.add_argument(
+        "--dry-run", action="store_true", help="Print what would be done, change nothing"
+    )
+    harness_install_parser.add_argument("--yes", action="store_true")
+    harness_install_parser.set_defaults(func=cmd_harness_install)
 
     ui_parser = subparsers.add_parser("ui", help="Launch the local Skill Atlas web UI")
     ui_parser.add_argument("--host", default="127.0.0.1")
@@ -588,6 +652,13 @@ def cmd_backend_astra_search(args: argparse.Namespace) -> None:
 
 
 def cmd_mcp_config(args: argparse.Namespace) -> None:
+    # Deprecation goes to stderr so `--json` stdout stays parseable.
+    print(
+        "skillroute: `mcp config --client` is deprecated; use "
+        f"`skillroute harness show {args.client}` (or `harness install`). "
+        "It will be removed in 0.3.",
+        file=sys.stderr,
+    )
     payload = build_mcp_setup(
         client=args.client,
         repo_root=args.repo_root,
@@ -600,6 +671,94 @@ def cmd_mcp_config(args: argparse.Namespace) -> None:
         print_json(payload)
         return
     print(render_mcp_setup(payload))
+
+
+def cmd_harness_list(args: argparse.Namespace) -> None:
+    manifests = [
+        manifest
+        for manifest in load_manifests().values()
+        if not args.mode or manifest.supports(args.mode)
+    ]
+    if args.as_json:
+        print_json(
+            [
+                {
+                    "id": manifest.id,
+                    "name": manifest.display_name,
+                    "tier": manifest.tier,
+                    "homepage": manifest.homepage,
+                    "modes": sorted(manifest.modes),
+                }
+                for manifest in manifests
+            ]
+        )
+        return
+    if not manifests:
+        print(f"No harnesses support mode {args.mode!r}.")
+        return
+    width = max(len(manifest.id) for manifest in manifests)
+    for manifest in manifests:
+        modes = " ".join(sorted(manifest.modes))
+        print(f"{manifest.id:<{width}}  {manifest.tier:<12}  {modes}")
+
+
+def cmd_harness_detect(args: argparse.Namespace) -> None:
+    detections = detect_harnesses()
+    if args.as_json:
+        print_json([asdict(detection) for detection in detections])
+        return
+    print_detection_summary(detections)
+
+
+def cmd_harness_show(args: argparse.Namespace) -> None:
+    payload = build_harness_setup(
+        harness=args.harness,
+        mode=args.mode,
+        repo_root=args.repo_root,
+        catalog=args.catalog,
+        backend=args.backend,
+        server_name=args.server_name,
+        scope=args.scope,
+        platform=args.platform,
+    )
+    if args.as_json:
+        print_json(payload)
+        return
+    print(render_harness_setup(payload))
+
+
+def cmd_harness_install(args: argparse.Namespace) -> None:
+    repo_root = (args.repo_root or default_repo_root()).expanduser().resolve()
+    payload = build_harness_setup(
+        harness=args.harness,
+        mode=args.mode,
+        repo_root=repo_root,
+        catalog=args.catalog,
+        backend=args.backend,
+        server_name=args.server_name,
+        scope=args.scope,
+    )
+    if args.dry_run:
+        print(render_harness_setup(payload))
+        return
+    detection = next(
+        (item for item in detect_harnesses() if item.id == args.harness), None
+    )
+    if detection is None:
+        raise SystemExit(f"Unknown harness: {args.harness}")
+    result = apply_harness_setup(
+        detection,
+        repo_root=repo_root,
+        catalog=args.catalog,
+        backend=args.backend,
+        server_name=args.server_name,
+        mode="1" if args.yes else "prompt",
+        yes=args.yes,
+        install_mode=args.mode,
+    )
+    print(f"{detection.name}: {result.status} - {result.message}")
+    if result.backup_path:
+        print(f"{detection.name}: backup - {result.backup_path}")
 
 
 def cmd_ui(args: argparse.Namespace) -> None:

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -23,6 +23,12 @@ from skillroute.backends import (
 from skillroute.catalog import Catalog, default_catalog_path
 from skillroute.dogfood import discover_default_skill_roots, index_default_skill_roots
 from skillroute.evals import run_golden_routes
+from skillroute.harness_doctor import (
+    DEFAULT_PROBE_TIMEOUT,
+    STATUS_FAIL,
+    render_doctor_reports,
+    run_doctor,
+)
 from skillroute.harness_render import (
     build_harness_setup,
     default_repo_root,
@@ -311,6 +317,35 @@ def build_parser() -> argparse.ArgumentParser:
     )
     harness_install_parser.add_argument("--yes", action="store_true")
     harness_install_parser.set_defaults(func=cmd_harness_install)
+
+    harness_doctor_parser = harness_subparsers.add_parser(
+        "doctor", help="Verify harness packs still match reality"
+    )
+    # No `choices=`: with nargs="*" argparse renders the empty-list default into
+    # the usage line. run_doctor() validates and names the valid ids instead.
+    harness_doctor_parser.add_argument(
+        "harness",
+        nargs="*",
+        metavar="HARNESS",
+        help=f"Harnesses to check (default: all). One of: {', '.join(HARNESS_IDS)}",
+    )
+    harness_doctor_parser.add_argument("--mode", default="mcp")
+    harness_doctor_parser.add_argument("--repo-root", type=Path, default=None)
+    harness_doctor_parser.add_argument("--server-name", default="skillroute")
+    add_backend_argument(harness_doctor_parser)
+    harness_doctor_parser.add_argument(
+        "--no-probe",
+        action="store_true",
+        help="Skip running the configured server; check the pack statically only",
+    )
+    harness_doctor_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_PROBE_TIMEOUT,
+        help="Seconds to wait for the server to answer initialize",
+    )
+    harness_doctor_parser.add_argument("--json", action="store_true", dest="as_json")
+    harness_doctor_parser.set_defaults(func=cmd_harness_doctor)
 
     ui_parser = subparsers.add_parser("ui", help="Launch the local Skill Atlas web UI")
     ui_parser.add_argument("--host", default="127.0.0.1")
@@ -759,6 +794,29 @@ def cmd_harness_install(args: argparse.Namespace) -> None:
     print(f"{detection.name}: {result.status} - {result.message}")
     if result.backup_path:
         print(f"{detection.name}: backup - {result.backup_path}")
+
+
+def cmd_harness_doctor(args: argparse.Namespace) -> None:
+    try:
+        reports = run_doctor(
+            args.harness or None,
+            repo_root=args.repo_root,
+            catalog=args.catalog,
+            backend=args.backend,
+            server_name=args.server_name,
+            mode=args.mode,
+            probe=not args.no_probe,
+            timeout=args.timeout,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if args.as_json:
+        print_json([report.to_dict() for report in reports])
+    else:
+        print(render_doctor_reports(reports))
+    # Non-zero exit so `harness doctor` is usable as a CI gate.
+    if any(report.status == STATUS_FAIL for report in reports):
+        raise SystemExit(1)
 
 
 def cmd_ui(args: argparse.Namespace) -> None:

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 import skillroute
+from skillroute.attribution import resolve_attribution
 from skillroute.backends import (
     BACKEND_CHOICES,
     AstraDataAPIBackend,
@@ -64,6 +65,11 @@ def build_parser() -> argparse.ArgumentParser:
     route_parser.add_argument("request")
     route_parser.add_argument("--repo", type=Path, default=None)
     route_parser.add_argument("--limit", type=int, default=5)
+    route_parser.add_argument(
+        "--harness",
+        default=None,
+        help="Attribute this route to a harness (defaults to $SKILLROUTE_HARNESS)",
+    )
     add_backend_argument(route_parser)
     route_parser.add_argument("--json", action="store_true", dest="as_json")
     route_parser.set_defaults(func=cmd_route)
@@ -306,7 +312,14 @@ def cmd_index(args: argparse.Namespace) -> None:
 
 def cmd_route(args: argparse.Namespace) -> None:
     catalog = catalog_from_args(args)
-    response = router_from_args(catalog, args).route(args.request, repo=args.repo, limit=args.limit)
+    response = router_from_args(catalog, args).route(
+        args.request,
+        repo=args.repo,
+        limit=args.limit,
+        attribution=resolve_attribution(
+            explicit=getattr(args, "harness", None), surface="cli"
+        ),
+    )
     if args.as_json:
         print_json(response)
         return

--- a/src/skillroute/client_setup.py
+++ b/src/skillroute/client_setup.py
@@ -1,379 +1,70 @@
+"""Deprecated compatibility shim over :mod:`skillroute.harness_setup`.
+
+v0.1 called agent tools "clients"; 0.2 calls them *harnesses* and declares them
+in ``harnesses/*.toml``. The names here are kept for one release so existing
+callers and scripts keep working, and will be removed in 0.3.
+"""
+
 from __future__ import annotations
 
-import argparse
-import datetime as dt
-import json
-import os
-import shutil
-import subprocess
-from dataclasses import asdict, dataclass
-from pathlib import Path
-from typing import Any
-
-from skillroute.catalog import default_catalog_path
-from skillroute.mcp_setup import MCP_CLIENT_CHOICES, build_mcp_setup
-
-CLIENT_ORDER = (
-    "ibm-bob",
-    "codex",
-    "claude-code",
-    "claude-desktop",
-    "vscode",
-    "windsurf",
-    "cursor",
+from skillroute.harness_setup import (
+    NO_TTY_SETUP_MESSAGE,
+    SetupResult,
+    build_parser,
+    can_prompt,
+    confirm,
+    main,
+    merge_json_config,
+    print_detection_summary,
+    run_detect_command,
+    run_setup_command,
 )
-CLIENT_SETUP_CHOICES = ("prompt", "0", "1")
-NO_TTY_SETUP_MESSAGE = (
-    "No terminal is available for client setup prompts; skipping automatic client configuration. "
-    "Re-run with --yes or SKILLROUTE_CLIENT_SETUP=1 to configure detected clients, "
-    "or use SKILLROUTE_CLIENT_SETUP=0 to skip this step."
+from skillroute.harness_setup import (
+    SETUP_CHOICES as CLIENT_SETUP_CHOICES,
 )
+from skillroute.harness_setup import (
+    HarnessDetection as ClientDetection,
+)
+from skillroute.harness_setup import (
+    HarnessEnvironment as ClientEnvironment,
+)
+from skillroute.harness_setup import (
+    apply_harness_setup as apply_client_setup,
+)
+from skillroute.harness_setup import (
+    detect_harnesses as detect_clients,
+)
+from skillroute.harness_setup import (
+    select_harnesses as select_clients,
+)
+from skillroute.harnesses import harness_ids
+
+__all__ = [
+    "CLIENT_ORDER",
+    "CLIENT_SETUP_CHOICES",
+    "NO_TTY_SETUP_MESSAGE",
+    "ClientDetection",
+    "ClientEnvironment",
+    "SetupResult",
+    "apply_client_setup",
+    "build_parser",
+    "can_prompt",
+    "confirm",
+    "detect_clients",
+    "main",
+    "merge_json_config",
+    "print_detection_summary",
+    "run_detect_command",
+    "run_setup_command",
+    "select_clients",
+]
 
 
-@dataclass(frozen=True, slots=True)
-class ClientDetection:
-    id: str
-    name: str
-    detected: bool
-    reason: str
-    setup_method: str
-    command: str | None = None
-    config_path: str | None = None
+def _client_order() -> tuple[str, ...]:
+    return harness_ids()
 
 
-@dataclass(frozen=True, slots=True)
-class SetupResult:
-    client: str
-    status: str
-    message: str
-    backup_path: str | None = None
-
-
-class ClientEnvironment:
-    def __init__(
-        self,
-        *,
-        home: Path | None = None,
-        commands: dict[str, str | None] | None = None,
-        existing_paths: set[Path] | None = None,
-    ) -> None:
-        self.home = (home or Path.home()).expanduser()
-        self._commands = commands
-        self._existing_paths = {path.expanduser() for path in existing_paths} if existing_paths is not None else None
-
-    def which(self, command: str) -> str | None:
-        if self._commands is not None:
-            return self._commands.get(command)
-        return shutil.which(command)
-
-    def exists(self, path: Path) -> bool:
-        expanded = path.expanduser()
-        if self._existing_paths is not None:
-            return expanded in self._existing_paths
-        return expanded.exists()
-
-    def bob_config_path(self) -> Path:
-        return self.home / ".bob" / "mcp.json"
-
-    def claude_desktop_config_path(self) -> Path:
-        return self.home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
-
-    def windsurf_config_path(self) -> Path:
-        return self.home / ".codeium" / "windsurf" / "mcp_config.json"
-
-    def cursor_config_path(self) -> Path:
-        return self.home / ".cursor" / "mcp.json"
-
-
-def detect_clients(env: ClientEnvironment | None = None) -> list[ClientDetection]:
-    env = env or ClientEnvironment()
-    detections = [
-        detect_bob(env),
-        detect_codex(env),
-        detect_claude_code(env),
-        detect_claude_desktop(env),
-        detect_vscode(env),
-        detect_windsurf(env),
-        detect_cursor(env),
-    ]
-    return sorted(detections, key=lambda detection: CLIENT_ORDER.index(detection.id))
-
-
-def detect_bob(env: ClientEnvironment) -> ClientDetection:
-    config_path = env.bob_config_path()
-    app_path = Path("/Applications/IBM Bob.app")
-    detected = env.exists(config_path) or env.exists(app_path)
-    reason = (
-        f"found {config_path if env.exists(config_path) else app_path}"
-        if detected
-        else "not found"
-    )
-    return ClientDetection("ibm-bob", "IBM Bob", detected, reason, "json_merge", config_path=str(config_path))
-
-
-def detect_codex(env: ClientEnvironment) -> ClientDetection:
-    command = env.which("codex")
-    return ClientDetection(
-        "codex",
-        "Codex",
-        bool(command),
-        f"found {command}" if command else "codex command not found",
-        "command",
-        command=command,
-    )
-
-
-def detect_claude_code(env: ClientEnvironment) -> ClientDetection:
-    command = env.which("claude")
-    return ClientDetection(
-        "claude-code",
-        "Claude Code",
-        bool(command),
-        f"found {command}" if command else "claude command not found",
-        "command",
-        command=command,
-    )
-
-
-def detect_claude_desktop(env: ClientEnvironment) -> ClientDetection:
-    config_path = env.claude_desktop_config_path()
-    app_path = Path("/Applications/Claude.app")
-    detected = env.exists(config_path) or env.exists(app_path)
-    reason = (
-        f"found {config_path if env.exists(config_path) else app_path}"
-        if detected
-        else "not found"
-    )
-    return ClientDetection(
-        "claude-desktop",
-        "Claude Desktop",
-        detected,
-        reason,
-        "json_merge",
-        config_path=str(config_path),
-    )
-
-
-def detect_vscode(env: ClientEnvironment) -> ClientDetection:
-    command = env.which("code") or env.which("code-insiders")
-    return ClientDetection(
-        "vscode",
-        "VS Code",
-        bool(command),
-        f"found {command}" if command else "code/code-insiders command not found",
-        "command",
-        command=command,
-    )
-
-
-def detect_windsurf(env: ClientEnvironment) -> ClientDetection:
-    config_path = env.windsurf_config_path()
-    app_path = Path("/Applications/Windsurf.app")
-    command = env.which("windsurf")
-    detected = bool(command) or env.exists(config_path) or env.exists(app_path)
-    if command:
-        reason = f"found {command}"
-    elif env.exists(config_path):
-        reason = f"found {config_path}"
-    elif env.exists(app_path):
-        reason = f"found {app_path}"
-    else:
-        reason = "not found"
-    return ClientDetection("windsurf", "Windsurf", detected, reason, "json_merge", config_path=str(config_path))
-
-
-def detect_cursor(env: ClientEnvironment) -> ClientDetection:
-    config_path = env.cursor_config_path()
-    app_path = Path("/Applications/Cursor.app")
-    command = env.which("cursor")
-    detected = bool(command) or env.exists(config_path) or env.exists(app_path)
-    if command:
-        reason = f"found {command}"
-    elif env.exists(config_path):
-        reason = f"found {config_path}"
-    elif env.exists(app_path):
-        reason = f"found {app_path}"
-    else:
-        reason = "not found"
-    return ClientDetection(
-        "cursor",
-        "Cursor",
-        detected,
-        reason,
-        "print_only",
-        command=command,
-        config_path=str(config_path),
-    )
-
-
-def select_clients(client_spec: str, detections: list[ClientDetection]) -> list[ClientDetection]:
-    by_id = {detection.id: detection for detection in detections}
-    if client_spec == "auto":
-        return [detection for detection in detections if detection.detected]
-    if client_spec == "all":
-        return detections
-    requested = [client.strip() for client in client_spec.split(",") if client.strip()]
-    unknown = sorted(set(requested) - set(MCP_CLIENT_CHOICES))
-    if unknown:
-        valid = ", ".join(MCP_CLIENT_CHOICES)
-        raise SystemExit(f"Unknown client(s): {', '.join(unknown)}. Expected: auto, all, or one of {valid}.")
-    return [by_id[client] for client in requested]
-
-
-def apply_client_setup(
-    detection: ClientDetection,
-    *,
-    repo_root: Path,
-    catalog: Path | None = None,
-    backend: str | None = None,
-    server_name: str = "skillroute",
-    yes: bool = False,
-    mode: str = "prompt",
-) -> SetupResult:
-    if mode == "0":
-        return SetupResult(detection.id, "skipped", "client setup disabled")
-    payload = build_mcp_setup(
-        client=detection.id,
-        repo_root=repo_root,
-        catalog=catalog,
-        backend=backend,
-        server_name=server_name,
-    )
-    if payload["setup_method"] == "print_only":
-        return SetupResult(detection.id, "printed", json.dumps(payload["config"], indent=2, sort_keys=True))
-    if mode == "prompt" and not yes and not confirm(f"Set up {detection.name} for SkillRoute"):
-        return SetupResult(detection.id, "skipped", "user skipped setup")
-    if payload["setup_method"] == "command":
-        if not detection.detected:
-            return SetupResult(detection.id, "skipped", detection.reason)
-        command_parts = list(payload["install_command_parts"])
-        if detection.id == "vscode" and detection.command:
-            command_parts[0] = detection.command
-        subprocess.run(command_parts, check=True)
-        return SetupResult(detection.id, "configured", payload["install_command"])
-    if detection.config_path is None:
-        return SetupResult(detection.id, "skipped", "no config path available")
-    backup_path = merge_json_config(Path(detection.config_path), payload["config"])
-    message = f"wrote {detection.config_path}"
-    return SetupResult(detection.id, "configured", message, backup_path=str(backup_path) if backup_path else None)
-
-
-def merge_json_config(path: Path, incoming: dict[str, Any]) -> Path | None:
-    path = path.expanduser()
-    existing: dict[str, Any] = {}
-    backup_path: Path | None = None
-    if path.exists():
-        existing = json.loads(path.read_text(encoding="utf-8") or "{}")
-        if not isinstance(existing, dict):
-            raise ValueError(f"Existing config is not a JSON object: {path}")
-        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d%H%M%S")
-        backup_path = path.with_name(f"{path.name}.bak-{timestamp}")
-        shutil.copy2(path, backup_path)
-
-    for key, value in incoming.items():
-        if isinstance(value, dict):
-            target = existing.setdefault(key, {})
-            if not isinstance(target, dict):
-                # ValueError, not TypeError: this is malformed on-disk data, not a caller bug
-                raise ValueError(f"Existing config field is not an object: {key}")  # noqa: TRY004
-            target.update(value)
-        else:
-            existing[key] = value
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return backup_path
-
-
-def confirm(prompt: str) -> bool:
-    try:
-        tty = open("/dev/tty", "r+", encoding="utf-8")  # noqa: SIM115 -- closed by `with tty:` below
-    except OSError as exc:
-        raise SystemExit("No terminal is available for prompts. Re-run with --yes or SKILLROUTE_CLIENT_SETUP=1.") from exc
-    with tty:
-        tty.write(f"? {prompt} [y/N] ")
-        tty.flush()
-        reply = tty.readline().strip().lower()
-    return reply in {"y", "yes"}
-
-
-def can_prompt() -> bool:
-    if os.isatty(0):
-        return True
-    try:
-        with open("/dev/tty", "r+", encoding="utf-8"):
-            return True
-    except OSError:
-        return False
-
-
-def print_detection_summary(detections: list[ClientDetection]) -> None:
-    print("Detected agent clients:")
-    for detection in detections:
-        marker = "found" if detection.detected else "missing"
-        print(f"- {detection.name}: {marker} ({detection.reason})")
-
-
-def run_setup_command(args: argparse.Namespace) -> None:
-    env = ClientEnvironment()
-    detections = detect_clients(env)
-    print_detection_summary(detections)
-    selected = select_clients(args.clients, detections)
-    if not selected:
-        print("No clients selected for setup.")
-        return
-    if args.mode == "prompt" and not args.yes and not can_prompt():
-        print(NO_TTY_SETUP_MESSAGE)
-        return
-    repo_root = args.repo_root.expanduser().resolve()
-    catalog = args.catalog.expanduser().resolve() if args.catalog else default_catalog_path(repo_root)
-    for detection in selected:
-        if args.clients == "auto" and not detection.detected:
-            continue
-        result = apply_client_setup(
-            detection,
-            repo_root=repo_root,
-            catalog=catalog,
-            backend=args.backend,
-            yes=args.yes,
-            mode=args.mode,
-        )
-        print(f"{detection.name}: {result.status} - {result.message}")
-        if result.backup_path:
-            print(f"{detection.name}: backup - {result.backup_path}")
-
-
-def run_detect_command(args: argparse.Namespace) -> None:
-    detections = detect_clients(ClientEnvironment())
-    if args.as_json:
-        print(json.dumps([asdict(detection) for detection in detections], indent=2, sort_keys=True))
-        return
-    print_detection_summary(detections)
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="python -m skillroute.client_setup")
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    detect_parser = subparsers.add_parser("detect", help="Detect supported agent clients")
-    detect_parser.add_argument("--json", action="store_true", dest="as_json")
-    detect_parser.set_defaults(func=run_detect_command)
-
-    setup_parser = subparsers.add_parser("setup", help="Detect and optionally configure agent clients")
-    setup_parser.add_argument("--repo-root", type=Path, required=True)
-    setup_parser.add_argument("--catalog", type=Path, default=None)
-    setup_parser.add_argument("--backend", default=None)
-    setup_parser.add_argument("--clients", default="auto")
-    setup_parser.add_argument("--mode", choices=CLIENT_SETUP_CHOICES, default="prompt")
-    setup_parser.add_argument("--yes", action="store_true")
-    setup_parser.set_defaults(func=run_setup_command)
-    return parser
-
-
-def main(argv: list[str] | None = None) -> None:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-    args.func(args)
-
+CLIENT_ORDER: tuple[str, ...] = _client_order()
 
 if __name__ == "__main__":
     main()

--- a/src/skillroute/dogfood.py
+++ b/src/skillroute/dogfood.py
@@ -4,13 +4,34 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from skillroute.catalog import Catalog
+from skillroute.harnesses import skill_discovery_globs
 from skillroute.parser import discover_skill_files
 
-DEFAULT_SKILL_ROOTS = (
-    ".codex/skills",
-    ".agents/skills",
-    ".codex/plugins/cache",
-)
+# Roots that belong to no single harness. Everything else now comes from the
+# manifests, so a harness's skills directory is declared once, in its pack.
+EXTRA_SKILL_ROOTS = (".agents/skills",)
+
+
+def default_skill_roots() -> tuple[str, ...]:
+    """Home-relative skill directories worth scanning.
+
+    v0.1 hardcoded three entries here and notably missed ``.claude/skills``.
+    Deriving them from the harness manifests means adding a harness with a
+    skills directory automatically makes it discoverable.
+    """
+    roots: list[str] = []
+    for candidate in (*skill_discovery_globs(), *EXTRA_SKILL_ROOTS):
+        relative = candidate.lstrip("~/")
+        if relative and relative not in roots:
+            roots.append(relative)
+    return tuple(roots)
+
+
+def __getattr__(name: str) -> object:
+    # Deprecated in 0.2: the hardcoded tuple became manifest-derived.
+    if name == "DEFAULT_SKILL_ROOTS":
+        return default_skill_roots()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @dataclass(slots=True)
@@ -28,13 +49,23 @@ class DogfoodIndexResult:
 def discover_default_skill_roots(home: Path | None = None) -> list[DogfoodRoot]:
     home_path = (home or Path.home()).expanduser().resolve()
     roots: list[DogfoodRoot] = []
-    for relative_root in DEFAULT_SKILL_ROOTS:
-        root = home_path / relative_root
-        if not root.is_dir():
-            continue
-        count = len(discover_skill_files(root))
-        if count:
-            roots.append(DogfoodRoot(path=root.resolve(), skill_count=count))
+    seen: set[Path] = set()
+    for relative_root in default_skill_roots():
+        # Manifests may declare globs (Claude Code's plugin skill dirs), so
+        # expand rather than treating every entry as a literal path.
+        candidates = (
+            sorted(home_path.glob(relative_root))
+            if any(char in relative_root for char in "*?[")
+            else [home_path / relative_root]
+        )
+        for root in candidates:
+            resolved = root.resolve()
+            if resolved in seen or not root.is_dir():
+                continue
+            seen.add(resolved)
+            count = len(discover_skill_files(root))
+            if count:
+                roots.append(DogfoodRoot(path=resolved, skill_count=count))
     return roots
 
 

--- a/src/skillroute/harness_doctor.py
+++ b/src/skillroute/harness_doctor.py
@@ -1,0 +1,438 @@
+"""Verify that a harness pack still describes reality.
+
+The manifests in ``harnesses/`` encode config paths for fourteen tools that each
+move on their own schedule. A path that was right when the pack was written is
+the kind of thing that rots silently: ``harness install`` keeps reporting
+success while writing to a file the tool no longer reads.
+
+``skillroute harness doctor`` is the check that catches that. It walks a pack
+end to end -- the manifest declares a path on this platform, every mode still
+renders, the config on disk actually names our server -- and then does the part
+that cannot be faked by inspection: it runs the configured server command and
+confirms it answers an MCP ``initialize`` handshake.
+
+Statuses are deliberately four-valued. Not having a tool installed is not a
+failure (you can doctor a pack for a harness you do not use), so absence is a
+warning and only real breakage is a failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from skillroute.catalog import default_catalog_path
+from skillroute.harness_render import build_harness_setup, default_repo_root
+from skillroute.harness_setup import HarnessDetection, HarnessEnvironment, detect_harness
+from skillroute.harnesses import (
+    HarnessManifest,
+    load_manifests,
+    manifest_for,
+)
+
+STATUS_OK = "ok"
+STATUS_WARN = "warn"
+STATUS_FAIL = "fail"
+STATUS_SKIP = "skip"
+
+# Ordered by severity; worst_status() takes the max.
+_SEVERITY = {STATUS_SKIP: 0, STATUS_OK: 1, STATUS_WARN: 2, STATUS_FAIL: 3}
+
+DEFAULT_PROBE_TIMEOUT = 20.0
+
+# Minimal MCP handshake. We send `initialize` and then EOF: a stdio server
+# answers and exits on a closed stdin, which lets one communicate() call cover
+# both the reply and the timeout without a reader thread.
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "skillroute-doctor", "version": "1"},
+    },
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorCheck:
+    name: str
+    status: str
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "status": self.status, "detail": self.detail}
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorReport:
+    harness: str
+    name: str
+    checks: tuple[DoctorCheck, ...] = field(default_factory=tuple)
+
+    @property
+    def status(self) -> str:
+        return worst_status(check.status for check in self.checks)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "harness": self.harness,
+            "name": self.name,
+            "status": self.status,
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+def worst_status(statuses: Any) -> str:
+    """The most severe status present, defaulting to ok for an empty run."""
+    worst = STATUS_OK
+    for status in statuses:
+        if _SEVERITY.get(status, 0) > _SEVERITY[worst]:
+            worst = status
+    return worst
+
+
+# --- individual checks ----------------------------------------------------
+
+
+def check_manifest(manifest: HarnessManifest) -> DoctorCheck:
+    if not manifest.modes:
+        return DoctorCheck("manifest", STATUS_FAIL, "declares no install modes")
+    modes = ", ".join(sorted(manifest.modes))
+    if manifest.tier == "unverified":
+        return DoctorCheck(
+            "manifest", STATUS_WARN, f"tier=unverified; modes: {modes}"
+        )
+    return DoctorCheck("manifest", STATUS_OK, f"tier={manifest.tier}; modes: {modes}")
+
+
+def check_platform(manifest: HarnessManifest, platform: str) -> DoctorCheck:
+    """Every mode that writes a file must name a path for this platform.
+
+    v0.1 detection was macOS-only. Encoding that as a check means a pack that
+    quietly omits Linux or Windows is caught by CI on that platform rather than
+    by a user.
+    """
+    missing = []
+    for name, mode in sorted(manifest.modes.items()):
+        # `command` and `print_only` modes drive the harness's own CLI or just
+        # print a snippet, so they legitimately have no path of ours to write.
+        if mode.setup_method in {"command", "print_only", "package"}:
+            continue
+        if not mode.path_for(platform) and not mode.skills_dir_for(platform):
+            missing.append(name)
+    if missing:
+        return DoctorCheck(
+            "platform",
+            STATUS_FAIL,
+            f"no {platform} path for mode(s): {', '.join(missing)}",
+        )
+    return DoctorCheck("platform", STATUS_OK, f"paths declared for {platform}")
+
+
+def check_detect(detection: HarnessDetection) -> DoctorCheck:
+    if detection.detected:
+        return DoctorCheck("detect", STATUS_OK, detection.reason)
+    # Not installed is a fact about this machine, not a defect in the pack.
+    return DoctorCheck("detect", STATUS_WARN, f"not installed ({detection.reason})")
+
+
+def check_render(
+    harness: str,
+    *,
+    repo_root: Path,
+    catalog: Path | None = None,
+    backend: str | None = None,
+    server_name: str = "skillroute",
+    platform: str | None = None,
+) -> list[DoctorCheck]:
+    """Render every declared mode; an unresolvable placeholder is a failure."""
+    manifest = manifest_for(harness)
+    checks: list[DoctorCheck] = []
+    for mode in sorted(manifest.modes):
+        try:
+            build_harness_setup(
+                harness=harness,
+                mode=mode,
+                repo_root=repo_root,
+                catalog=catalog,
+                backend=backend,
+                server_name=server_name,
+                platform=platform,
+            )
+        except Exception as exc:  # noqa: BLE001 -- any render failure is a pack defect
+            checks.append(
+                DoctorCheck(f"render:{mode}", STATUS_FAIL, f"{type(exc).__name__}: {exc}")
+            )
+        else:
+            checks.append(DoctorCheck(f"render:{mode}", STATUS_OK, "renders"))
+    return checks
+
+
+def check_config(path: Path, *, server_name: str, config_format: str) -> DoctorCheck:
+    """Does the on-disk config actually name our server?
+
+    This is the check that catches a path the harness stopped reading: install
+    reports success, the file exists, and the tool never sees it. We can only
+    assert this for JSON; YAML and TOML configs are reported as unverified
+    rather than guessed at.
+    """
+    if config_format != "json":
+        return DoctorCheck(
+            "config", STATUS_SKIP, f"{config_format} config not inspected"
+        )
+    if not path.exists():
+        return DoctorCheck("config", STATUS_WARN, f"not configured yet: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8") or "{}")
+    except (OSError, json.JSONDecodeError) as exc:
+        return DoctorCheck("config", STATUS_FAIL, f"cannot parse {path}: {exc}")
+    if not isinstance(raw, dict):
+        return DoctorCheck("config", STATUS_FAIL, f"cannot parse {path}: not an object")
+    if _names_server(raw, server_name):
+        return DoctorCheck("config", STATUS_OK, f"{server_name} present in {path}")
+    return DoctorCheck(
+        "config", STATUS_WARN, f"{server_name} not found in {path}"
+    )
+
+
+def _names_server(raw: Any, server_name: str) -> bool:
+    """Look for the server key anywhere; emitters nest it under varying roots."""
+    if isinstance(raw, dict):
+        if server_name in raw:
+            return True
+        return any(_names_server(value, server_name) for value in raw.values())
+    if isinstance(raw, list):
+        return any(_names_server(item, server_name) for item in raw)
+    return False
+
+
+def probe_server(
+    argv: list[str],
+    *,
+    env: dict[str, str],
+    timeout: float = DEFAULT_PROBE_TIMEOUT,
+) -> DoctorCheck:
+    """Run the configured server and confirm it answers ``initialize``.
+
+    This is the only check that proves the config points at something that
+    works, rather than at a path that merely exists.
+    """
+    if not argv:
+        return DoctorCheck("server", STATUS_SKIP, "no server command to probe")
+    request = json.dumps(_INITIALIZE) + "\n"
+    try:
+        process = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, **env},
+        )
+    except (OSError, ValueError) as exc:
+        return DoctorCheck("server", STATUS_FAIL, f"cannot start {argv[0]}: {exc}")
+
+    try:
+        stdout, stderr = process.communicate(input=request, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.communicate()
+        return DoctorCheck(
+            "server", STATUS_FAIL, f"did not answer initialize within {timeout:g}s"
+        )
+
+    reply = _first_json_object(stdout)
+    if reply is None:
+        summary = _error_summary(stderr or stdout)
+        if process.returncode:
+            return DoctorCheck(
+                "server", STATUS_FAIL, f"exit {process.returncode}: {summary}"
+            )
+        return DoctorCheck("server", STATUS_FAIL, f"no JSON-RPC reply: {summary}")
+    if "error" in reply:
+        message = reply["error"].get("message", "unknown error")
+        return DoctorCheck("server", STATUS_FAIL, f"initialize failed: {message}")
+    info = (reply.get("result") or {}).get("serverInfo") or {}
+    label = " ".join(part for part in (info.get("name"), info.get("version")) if part)
+    return DoctorCheck("server", STATUS_OK, f"answered initialize: {label or 'ok'}")
+
+
+def _error_summary(stream: str) -> str:
+    """Pick the most diagnostic line from a failed server's output.
+
+    Node prints ``Error: Cannot find module ...`` and then several lines of
+    version banner, so the last line is the least useful thing available.
+    """
+    lines = [line.strip() for line in (stream or "").splitlines() if line.strip()]
+    if not lines:
+        return "no output"
+    for line in lines:
+        if "error" in line.casefold():
+            return line
+    return lines[0]
+
+
+def _first_json_object(stream: str) -> dict[str, Any] | None:
+    for line in (stream or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+# --- driver ---------------------------------------------------------------
+
+
+def run_doctor(
+    harnesses: list[str] | tuple[str, ...] | None = None,
+    *,
+    env: HarnessEnvironment | None = None,
+    repo_root: Path | None = None,
+    catalog: Path | None = None,
+    backend: str | None = None,
+    server_name: str = "skillroute",
+    mode: str = "mcp",
+    probe: bool = True,
+    timeout: float = DEFAULT_PROBE_TIMEOUT,
+) -> list[DoctorReport]:
+    """Check one or more harness packs. Empty selection means every pack."""
+    manifests = load_manifests()
+    selected = list(harnesses) if harnesses else sorted(manifests)
+    unknown = [item for item in selected if item not in manifests]
+    if unknown:
+        valid = ", ".join(sorted(manifests))
+        raise ValueError(
+            f"Unsupported harness {', '.join(unknown)!r}; expected one of: {valid}"
+        )
+
+    env = env or HarnessEnvironment()
+    resolved_root = (repo_root or default_repo_root()).expanduser().resolve()
+    resolved_catalog = (
+        catalog.expanduser().resolve() if catalog else default_catalog_path(resolved_root)
+    )
+
+    reports: list[DoctorReport] = []
+    for harness in selected:
+        manifest = manifests[harness]
+        detection = detect_harness(manifest, env)
+        checks: list[DoctorCheck] = [
+            check_manifest(manifest),
+            check_platform(manifest, env.platform),
+            check_detect(detection),
+        ]
+        checks.extend(
+            check_render(
+                harness,
+                repo_root=resolved_root,
+                catalog=resolved_catalog,
+                backend=backend,
+                server_name=server_name,
+                platform=env.platform,
+            )
+        )
+        checks.append(
+            _config_check_for(manifest, detection, mode=mode, server_name=server_name)
+        )
+        checks.append(
+            _probe_check_for(
+                harness,
+                detection,
+                mode=mode,
+                repo_root=resolved_root,
+                catalog=resolved_catalog,
+                backend=backend,
+                server_name=server_name,
+                probe=probe,
+                timeout=timeout,
+            )
+        )
+        reports.append(
+            DoctorReport(harness=harness, name=manifest.display_name, checks=tuple(checks))
+        )
+    return reports
+
+
+def _config_check_for(
+    manifest: HarnessManifest,
+    detection: HarnessDetection,
+    *,
+    mode: str,
+    server_name: str,
+) -> DoctorCheck:
+    install = manifest.mode(mode)
+    if install is None:
+        return DoctorCheck("config", STATUS_SKIP, f"no {mode} mode")
+    if detection.config_path is None:
+        return DoctorCheck("config", STATUS_SKIP, "no config path on this platform")
+    return check_config(
+        Path(detection.config_path),
+        server_name=server_name,
+        config_format=install.config_format,
+    )
+
+
+def _probe_check_for(
+    harness: str,
+    detection: HarnessDetection,
+    *,
+    mode: str,
+    repo_root: Path,
+    catalog: Path,
+    backend: str | None,
+    server_name: str,
+    probe: bool,
+    timeout: float,
+) -> DoctorCheck:
+    if not probe:
+        return DoctorCheck("server", STATUS_SKIP, "probe disabled")
+    if not detection.detected:
+        return DoctorCheck("server", STATUS_SKIP, "harness not installed")
+    try:
+        payload = build_harness_setup(
+            harness=harness,
+            mode=mode,
+            repo_root=repo_root,
+            catalog=catalog,
+            backend=backend,
+            server_name=server_name,
+        )
+    except Exception as exc:  # noqa: BLE001 -- already reported by check_render
+        return DoctorCheck("server", STATUS_SKIP, f"cannot build config: {exc}")
+    server = payload.get("server_config") or {}
+    command = server.get("command")
+    if not command:
+        return DoctorCheck("server", STATUS_SKIP, "no stdio server command")
+    argv = [command, *server.get("args", [])]
+    return probe_server(argv, env=dict(server.get("env") or {}), timeout=timeout)
+
+
+def render_doctor_reports(reports: list[DoctorReport]) -> str:
+    """Plain-text rendering. Kept here so the CLI stays a thin caller."""
+    marks = {STATUS_OK: "ok", STATUS_WARN: "warn", STATUS_FAIL: "FAIL", STATUS_SKIP: "--"}
+    lines: list[str] = []
+    for report in reports:
+        lines.append(f"{report.name} ({report.harness}): {marks[report.status]}")
+        width = max((len(check.name) for check in report.checks), default=0)
+        for check in report.checks:
+            lines.append(
+                f"  {marks[check.status]:<4} {check.name:<{width}}  {check.detail}"
+            )
+        lines.append("")
+    failed = [report.harness for report in reports if report.status == STATUS_FAIL]
+    if failed:
+        lines.append(f"{len(failed)} harness(es) failed: {', '.join(failed)}")
+    else:
+        lines.append(f"{len(reports)} harness(es) checked, no failures.")
+    return "\n".join(lines)

--- a/src/skillroute/harness_render.py
+++ b/src/skillroute/harness_render.py
@@ -1,0 +1,438 @@
+"""Render a harness manifest into a concrete setup payload.
+
+This replaces the if/elif chain that used to live in ``mcp_setup``. Every
+per-client quirk that chain encoded is now either a manifest field or one of a
+small, closed set of named *emitters* below.
+
+An emitter owns exactly one config *shape*. Adding a harness whose config looks
+like an existing shape is pure data; a genuinely new shape adds one function
+here plus its test, which is a deliberate reviewable event rather than routine
+work. Six of the fourteen shipped harnesses share ``mcp_servers`` unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from skillroute.catalog import default_catalog_path
+from skillroute.harnesses import (
+    HarnessManifest,
+    InstallMode,
+    current_platform,
+    harness_ids,
+    manifest_for,
+)
+
+PLACEHOLDER = re.compile(r"\{([a-z_]+)\}")
+
+# Expand to several argv entries rather than one string, so they are only valid
+# as a whole array element.
+SPLAT_PLACEHOLDERS = frozenset({"server_argv"})
+
+
+class RenderError(ValueError):
+    """A manifest referenced something the render context cannot supply."""
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def shell_command(parts: list[str]) -> str:
+    return shlex.join(parts)
+
+
+def build_harness_setup(
+    *,
+    harness: str,
+    mode: str = "mcp",
+    repo_root: Path | None = None,
+    catalog: Path | None = None,
+    backend: str | None = None,
+    server_name: str = "skillroute",
+    scope: str | None = None,
+    platform: str | None = None,
+    server_argv: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the install payload for one harness and mode."""
+    manifest = manifest_for(harness)
+    install = manifest.mode(mode)
+    if install is None:
+        available = ", ".join(sorted(manifest.modes)) or "none"
+        raise ValueError(
+            f"Harness {harness!r} does not support mode {mode!r}; available: {available}"
+        )
+
+    resolved_scope = _resolve_scope(install, scope, harness=harness)
+    resolved_platform = platform or current_platform()
+    resolved_repo_root = (repo_root or default_repo_root()).expanduser().resolve()
+    catalog_path = (
+        catalog.expanduser().resolve() if catalog else default_catalog_path(resolved_repo_root)
+    )
+    selected_backend = (
+        backend or os.environ.get("SKILLROUTE_BACKEND") or "local"
+    ).strip().lower()
+    entrypoint = resolved_repo_root / "mcp" / "build" / "index.js"
+    argv = list(server_argv) if server_argv else ["node", str(entrypoint)]
+
+    env = {
+        "SKILLROUTE_CATALOG_PATH": str(catalog_path),
+        "SKILLROUTE_BACKEND": selected_backend,
+    }
+    stdio_server_config: dict[str, Any] = {
+        "command": argv[0],
+        "args": argv[1:],
+        "env": env,
+    }
+
+    context: dict[str, Any] = {
+        "harness_id": manifest.id,
+        "server_name": server_name,
+        "catalog": str(catalog_path),
+        "backend": selected_backend,
+        "repo_root": str(resolved_repo_root),
+        "scope": resolved_scope or "",
+        "server_argv": argv,
+    }
+
+    extra = {key: _substitute(value, context) for key, value in install.extra.items()}
+    emitter = EMITTERS.get(install.emitter)
+    config: Any = None
+    server_config: dict[str, Any] = stdio_server_config
+    if emitter is not None:
+        config, server_config = emitter(
+            server_name=server_name,
+            stdio=stdio_server_config,
+            extra=extra,
+            context=context,
+        )
+
+    # `{server_json}` needs the emitter's server_config, so it joins the context
+    # only after the emitter has run.
+    context["server_json"] = json.dumps(server_config, sort_keys=True)
+
+    notes = [
+        "Run ./scripts/bootstrap.sh first if mcp/build/index.js does not exist.",
+        "The generated config points at this local checkout and catalog.",
+    ]
+    if not entrypoint.exists():
+        notes.append(f"MCP entrypoint not found yet: {entrypoint}")
+    notes.extend(install.notes)
+
+    install_command_parts = (
+        _render_argv(install.argv, context) if install.setup_method == "command" else None
+    )
+
+    payload: dict[str, Any] = {
+        "harness": manifest.id,
+        # Retained so pre-0.2 callers of build_mcp_setup() keep working.
+        "client": manifest.id,
+        "mode": mode,
+        "server_name": server_name,
+        "repo_root": str(resolved_repo_root),
+        "mcp_entrypoint": str(entrypoint),
+        "catalog": str(catalog_path),
+        "backend": selected_backend,
+        "server_config": server_config,
+        "notes": notes,
+        "install_command": (
+            shell_command(install_command_parts) if install_command_parts else None
+        ),
+        "install_command_parts": install_command_parts,
+        "config_path": _config_path_display(install, resolved_scope),
+        "config_format": install.config_format,
+        "setup_method": install.setup_method,
+        "config": config,
+        "write_path": install.path_for(resolved_platform, resolved_scope or ""),
+    }
+    if resolved_scope:
+        payload["scope"] = resolved_scope
+    return payload
+
+
+def _resolve_scope(install: InstallMode, scope: str | None, *, harness: str) -> str | None:
+    if not install.scopes:
+        return None
+    resolved = scope or install.default_scope
+    if resolved and resolved not in install.scopes:
+        valid = ", ".join(install.scopes)
+        raise ValueError(
+            f"Unsupported scope {resolved!r} for {harness}; expected one of: {valid}"
+        )
+    return resolved
+
+
+def _config_path_display(install: InstallMode, scope: str | None) -> str:
+    if scope and scope in install.scope_paths:
+        return install.scope_paths[scope]
+    return install.config_path_display
+
+
+def _substitute(value: Any, context: dict[str, Any]) -> Any:
+    """Replace ``{name}`` placeholders, raising on anything undeclared.
+
+    Unknown placeholders are a manifest bug, and the conformance suite catches
+    them at test time rather than letting them reach a user's terminal.
+    """
+    if isinstance(value, str):
+        def replace(match: re.Match[str]) -> str:
+            key = match.group(1)
+            if key not in context:
+                raise RenderError(f"Unknown placeholder {{{key}}}")
+            replacement = context[key]
+            if isinstance(replacement, list):
+                raise RenderError(
+                    f"Placeholder {{{key}}} expands to multiple values and cannot be "
+                    "used inside a string"
+                )
+            return str(replacement)
+
+        return PLACEHOLDER.sub(replace, value)
+    if isinstance(value, dict):
+        return {key: _substitute(item, context) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_substitute(item, context) for item in value]
+    return value
+
+
+def _render_argv(argv: tuple[str, ...], context: dict[str, Any]) -> list[str]:
+    rendered: list[str] = []
+    for entry in argv:
+        match = PLACEHOLDER.fullmatch(entry)
+        if match and match.group(1) in SPLAT_PLACEHOLDERS:
+            rendered.extend(str(item) for item in context[match.group(1)])
+            continue
+        rendered.append(_substitute(entry, context))
+    return rendered
+
+
+# --- emitters ------------------------------------------------------------
+#
+# Each returns (config, server_config). `config` is what gets written or printed;
+# `server_config` is the single-server object, which some harnesses embed
+# differently from how they store it.
+
+EmitterResult = tuple[Any, dict[str, Any]]
+
+
+def emit_mcp_servers(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """`{"mcpServers": {name: {...}}}` -- the de facto standard shape."""
+    return {"mcpServers": {server_name: {**stdio, **extra}}}, stdio
+
+
+def emit_vscode_servers(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """VS Code: top-level `servers`, and the name lives inside the object."""
+    server_config = {"name": server_name, **stdio, **extra}
+    return {"servers": {server_name: stdio}}, server_config
+
+
+def emit_opencode_mcp(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """OpenCode: nested under `mcp`, with an explicit local/remote type."""
+    server_config = {
+        "type": "local",
+        "command": [stdio["command"], *stdio["args"]],
+        "enabled": True,
+        "environment": stdio["env"],
+        **extra,
+    }
+    return {"mcp": {server_name: server_config}}, server_config
+
+
+def emit_zed_context_servers(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """Zed: `context_servers`, with the command split into its own object."""
+    server_config = {
+        "source": "custom",
+        "command": stdio["command"],
+        "args": stdio["args"],
+        "env": stdio["env"],
+        **extra,
+    }
+    return {"context_servers": {server_name: server_config}}, server_config
+
+
+def emit_amp_mcp_servers(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """Amp: same object shape, namespaced under an `amp.` settings key."""
+    return {"amp.mcpServers": {server_name: {**stdio, **extra}}}, stdio
+
+
+def emit_codex_toml(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """Codex: a TOML snippet, rendered as text.
+
+    Hand-rendered rather than written with a TOML library because SkillRoute
+    never merges into a user's TOML file -- this is only ever printed.
+    """
+    lines = [
+        f"[mcp_servers.{_toml_table_name(server_name)}]",
+        f"command = {_toml_string(stdio['command'])}",
+        f"args = [{', '.join(_toml_string(arg) for arg in stdio['args'])}]",
+    ]
+    if "cwd" in extra:
+        lines.append(f"cwd = {_toml_string(str(extra['cwd']))}")
+    env_pairs = ", ".join(
+        f"{key} = {_toml_string(value)}" for key, value in sorted(stdio["env"].items())
+    )
+    lines.append(f"env = {{ {env_pairs} }}")
+    for key, value in extra.items():
+        if key == "cwd":
+            continue
+        lines.append(f"{key} = {_toml_value(value)}")
+    return "\n".join(lines), stdio
+
+
+def emit_yaml_map(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """A YAML map under a configurable key, for Goose and Hermes.
+
+    Hand-rendered for the same reason as the TOML emitter, and deliberately
+    minimal: it only ever emits a flat map of scalars and string lists, which is
+    all these configs need. Adding PyYAML for two harnesses is not worth it.
+    """
+    container = str(extra.get("container", "mcp_servers"))
+    indent = "  "
+    lines = [f"{container}:", f"{indent}{server_name}:"]
+    lines.append(f"{indent * 2}cmd: {_yaml_scalar(stdio['command'])}")
+    if stdio["args"]:
+        lines.append(f"{indent * 2}args:")
+        lines.extend(f"{indent * 3}- {_yaml_scalar(arg)}" for arg in stdio["args"])
+    lines.append(f"{indent * 2}enabled: true")
+    lines.append(f"{indent * 2}type: stdio")
+    if stdio["env"]:
+        lines.append(f"{indent * 2}envs:")
+        lines.extend(
+            f"{indent * 3}{key}: {_yaml_scalar(value)}"
+            for key, value in sorted(stdio["env"].items())
+        )
+    return "\n".join(lines), stdio
+
+
+def emit_claude_session_start_hook(
+    *, server_name: str, stdio: dict[str, Any], extra: dict[str, Any], context: dict[str, Any]
+) -> EmitterResult:
+    """A Claude Code SessionStart hook entry."""
+    command = shell_command(["skillroute", "hook", "session-start"])
+    config = {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "matcher": "*",
+                    "hooks": [{"type": "command", "command": command, "timeout": 20}],
+                }
+            ]
+        }
+    }
+    return config, stdio
+
+
+Emitter = Callable[..., EmitterResult]
+
+EMITTERS: dict[str, Emitter] = {
+    "mcp_servers": emit_mcp_servers,
+    "vscode_servers": emit_vscode_servers,
+    "opencode_mcp": emit_opencode_mcp,
+    "zed_context_servers": emit_zed_context_servers,
+    "amp_mcp_servers": emit_amp_mcp_servers,
+    "codex_toml": emit_codex_toml,
+    "yaml_map": emit_yaml_map,
+    "claude_session_start_hook": emit_claude_session_start_hook,
+}
+
+
+def _toml_table_name(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        return value
+    return _toml_string(value)
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    return _toml_string(str(value))
+
+
+def _yaml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    text = str(value)
+    if text and re.fullmatch(r"[A-Za-z0-9_./@:-]+", text):
+        return text
+    return json.dumps(text)
+
+
+def mode_label(mode: str) -> str:
+    """Display form of a mode name: acronyms stay uppercase, the rest read as words."""
+    acronyms = {"mcp": "MCP", "acp": "ACP"}
+    return acronyms.get(mode, mode.replace("_", " "))
+
+
+def render_harness_setup(payload: dict[str, Any]) -> str:
+    manifest = manifest_for(payload["harness"])
+    lines = [
+        f"SkillRoute {mode_label(payload['mode'])} setup for {manifest.display_name}",
+        f"server: {payload['server_name']}",
+        f"catalog: {payload['catalog']}",
+        f"backend: {payload['backend']}",
+        "",
+    ]
+    if payload.get("install_command"):
+        lines.extend(["Install command:", payload["install_command"], ""])
+    lines.extend(
+        [f"Config path: {payload['config_path']}", f"Config format: {payload['config_format']}", ""]
+    )
+    lines.append("Config snippet:")
+    config = payload["config"]
+    if isinstance(config, str):
+        lines.append(config)
+    else:
+        lines.append(json.dumps(config, indent=2, sort_keys=True))
+    if payload.get("notes"):
+        lines.extend(["", "Notes:"])
+        lines.extend(f"- {note}" for note in payload["notes"])
+    return "\n".join(lines)
+
+
+def harness_display_name(harness: str) -> str:
+    try:
+        return manifest_for(harness).display_name
+    except ValueError:
+        return harness
+
+
+def supported_harnesses() -> tuple[str, ...]:
+    return harness_ids()
+
+
+def modes_for(harness: str) -> tuple[str, ...]:
+    return tuple(sorted(manifest_for(harness).modes))
+
+
+def manifests_supporting(mode: str) -> list[HarnessManifest]:
+    from skillroute.harnesses import load_manifests
+
+    return [
+        manifest for manifest in load_manifests().values() if manifest.supports(mode)
+    ]

--- a/src/skillroute/harness_render.py
+++ b/src/skillroute/harness_render.py
@@ -35,6 +35,19 @@ PLACEHOLDER = re.compile(r"\{([a-z_]+)\}")
 # as a whole array element.
 SPLAT_PLACEHOLDERS = frozenset({"server_argv"})
 
+NPM_PACKAGE = "@skillroute/mcp-server"
+
+# How a generated config names the MCP server. `local` points at a built
+# checkout, which is the only thing that works before the package is published;
+# `npx` points at the published package, which is the only thing that works for
+# anyone who did not clone the repo.
+SERVER_SOURCES = ("local", "npx")
+
+# The S2 switch. Flipping this to "npx" changes what every generated config
+# points at, so it stays "local" until @skillroute/mcp-server is actually on
+# npm -- otherwise `harness install` would emit configs that resolve to nothing.
+DEFAULT_SERVER_SOURCE = "local"
+
 
 class RenderError(ValueError):
     """A manifest referenced something the render context cannot supply."""
@@ -42,6 +55,25 @@ class RenderError(ValueError):
 
 def default_repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def local_entrypoint(repo_root: Path) -> Path:
+    return repo_root / "mcp" / "build" / "index.js"
+
+
+def server_argv_for(
+    source: str, *, repo_root: Path, package: str = NPM_PACKAGE
+) -> list[str]:
+    """The argv a generated config should use to start the MCP server."""
+    if source == "npx":
+        # `-y` so a first run does not stop at an install prompt inside a
+        # harness that gives the server no terminal.
+        return ["npx", "-y", package]
+    if source == "local":
+        return ["node", str(local_entrypoint(repo_root))]
+    raise RenderError(
+        f"Unknown server source {source!r}; expected one of: {', '.join(SERVER_SOURCES)}"
+    )
 
 
 def shell_command(parts: list[str]) -> str:
@@ -59,6 +91,7 @@ def build_harness_setup(
     scope: str | None = None,
     platform: str | None = None,
     server_argv: list[str] | None = None,
+    server_source: str | None = None,
 ) -> dict[str, Any]:
     """Build the install payload for one harness and mode."""
     manifest = manifest_for(harness)
@@ -78,8 +111,13 @@ def build_harness_setup(
     selected_backend = (
         backend or os.environ.get("SKILLROUTE_BACKEND") or "local"
     ).strip().lower()
-    entrypoint = resolved_repo_root / "mcp" / "build" / "index.js"
-    argv = list(server_argv) if server_argv else ["node", str(entrypoint)]
+    entrypoint = local_entrypoint(resolved_repo_root)
+    resolved_source = server_source or DEFAULT_SERVER_SOURCE
+    argv = (
+        list(server_argv)
+        if server_argv
+        else server_argv_for(resolved_source, repo_root=resolved_repo_root)
+    )
 
     env = {
         "SKILLROUTE_CATALOG_PATH": str(catalog_path),
@@ -117,12 +155,18 @@ def build_harness_setup(
     # only after the emitter has run.
     context["server_json"] = json.dumps(server_config, sort_keys=True)
 
-    notes = [
-        "Run ./scripts/bootstrap.sh first if mcp/build/index.js does not exist.",
-        "The generated config points at this local checkout and catalog.",
-    ]
-    if not entrypoint.exists():
-        notes.append(f"MCP entrypoint not found yet: {entrypoint}")
+    if resolved_source == "local":
+        notes = [
+            "Run ./scripts/bootstrap.sh first if mcp/build/index.js does not exist.",
+            "The generated config points at this local checkout and catalog.",
+        ]
+        if not entrypoint.exists():
+            notes.append(f"MCP entrypoint not found yet: {entrypoint}")
+    else:
+        notes = [
+            f"The generated config runs the published {NPM_PACKAGE} via npx.",
+            "npx resolves the package on first run, so that run is slower.",
+        ]
     notes.extend(install.notes)
 
     install_command_parts = (
@@ -137,6 +181,7 @@ def build_harness_setup(
         "server_name": server_name,
         "repo_root": str(resolved_repo_root),
         "mcp_entrypoint": str(entrypoint),
+        "server_source": resolved_source,
         "catalog": str(catalog_path),
         "backend": selected_backend,
         "server_config": server_config,

--- a/src/skillroute/harness_render.py
+++ b/src/skillroute/harness_render.py
@@ -135,11 +135,22 @@ def build_harness_setup(
         "catalog": str(catalog_path),
         "backend": selected_backend,
         "repo_root": str(resolved_repo_root),
+        # Where the server process should run. Only a checkout has a meaningful
+        # working directory; an npx-resolved package does not, so this renders
+        # empty and the key it fills is dropped below.
+        "server_cwd": str(resolved_repo_root) if resolved_source == "local" else "",
         "scope": resolved_scope or "",
         "server_argv": argv,
     }
 
-    extra = {key: _substitute(value, context) for key, value in install.extra.items()}
+    # An extra that renders empty is one the manifest declared for a situation
+    # that does not apply here (cwd under npx). Emitting `cwd: ""` would be
+    # worse than omitting it -- some harnesses treat it as a real path.
+    extra = {
+        key: rendered
+        for key, value in install.extra.items()
+        if (rendered := _substitute(value, context)) != ""
+    }
     emitter = EMITTERS.get(install.emitter)
     config: Any = None
     server_config: dict[str, Any] = stdio_server_config

--- a/src/skillroute/harness_setup.py
+++ b/src/skillroute/harness_setup.py
@@ -1,0 +1,339 @@
+"""Detect installed harnesses and apply their setup.
+
+v0.1 had one hand-written ``detect_*`` function per client plus a hardcoded
+ordering tuple. Detection is now one loop over the manifests: a harness is
+present if any command it declares is on PATH, or any path or app bundle it
+declares exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from skillroute.catalog import default_catalog_path
+from skillroute.harness_render import build_harness_setup
+from skillroute.harnesses import (
+    HarnessManifest,
+    current_platform,
+    harness_ids,
+    load_manifests,
+)
+
+SETUP_CHOICES = ("prompt", "0", "1")
+NO_TTY_SETUP_MESSAGE = (
+    "No terminal is available for client setup prompts; skipping automatic client configuration. "
+    "Re-run with --yes or SKILLROUTE_CLIENT_SETUP=1 to configure detected clients, "
+    "or use SKILLROUTE_CLIENT_SETUP=0 to skip this step."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessDetection:
+    id: str
+    name: str
+    detected: bool
+    reason: str
+    setup_method: str
+    command: str | None = None
+    config_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SetupResult:
+    client: str
+    status: str
+    message: str
+    backup_path: str | None = None
+
+
+class HarnessEnvironment:
+    """Injectable view of the machine, so detection is testable without one."""
+
+    def __init__(
+        self,
+        *,
+        home: Path | None = None,
+        commands: dict[str, str | None] | None = None,
+        existing_paths: set[Path] | None = None,
+        platform: str | None = None,
+    ) -> None:
+        self.home = (home or Path.home()).expanduser()
+        self.platform = platform or current_platform()
+        self._commands = commands
+        self._existing_paths = (
+            {path.expanduser() for path in existing_paths}
+            if existing_paths is not None
+            else None
+        )
+
+    def which(self, command: str) -> str | None:
+        if self._commands is not None:
+            return self._commands.get(command)
+        return shutil.which(command)
+
+    def exists(self, path: Path) -> bool:
+        expanded = path.expanduser()
+        if self._existing_paths is not None:
+            return expanded in self._existing_paths
+        return expanded.exists()
+
+    def resolve(self, raw: str) -> Path:
+        """Expand a manifest path against this environment's home.
+
+        Tests inject a fake home, so ``~`` must not go through
+        ``Path.expanduser()``, which would read the real one.
+        """
+        expanded = os.path.expandvars(raw)
+        if expanded.startswith("~"):
+            return self.home / expanded.lstrip("~/\\")
+        return Path(expanded)
+
+
+def detect_harnesses(env: HarnessEnvironment | None = None) -> list[HarnessDetection]:
+    env = env or HarnessEnvironment()
+    detections = [
+        detect_harness(manifest, env) for manifest in load_manifests().values()
+    ]
+    return sorted(detections, key=lambda detection: detection.id)
+
+
+def detect_harness(manifest: HarnessManifest, env: HarnessEnvironment) -> HarnessDetection:
+    mcp = manifest.mode("mcp")
+    setup_method = mcp.setup_method if mcp else "print_only"
+    config_path = mcp.path_for(env.platform) if mcp else ""
+
+    found_command: str | None = None
+    for command in manifest.detect.commands:
+        resolved = env.which(command)
+        if resolved:
+            found_command = resolved
+            break
+
+    found_path: Path | None = None
+    for raw in (*manifest.detect.paths_for(env.platform), *manifest.detect.apps_for(env.platform)):
+        candidate = env.resolve(raw)
+        if env.exists(candidate):
+            found_path = candidate
+            break
+
+    detected = bool(found_command) or found_path is not None
+    if found_command:
+        reason = f"found {found_command}"
+    elif found_path is not None:
+        reason = f"found {found_path}"
+    elif manifest.detect.commands and not (
+        manifest.detect.paths_for(env.platform) or manifest.detect.apps_for(env.platform)
+    ):
+        # Command-only harnesses name the binary they looked for; anything with
+        # paths to check would make that message misleading.
+        reason = f"{'/'.join(manifest.detect.commands)} command not found"
+    else:
+        reason = "not found"
+
+    return HarnessDetection(
+        id=manifest.id,
+        name=manifest.display_name,
+        detected=detected,
+        reason=reason,
+        setup_method=setup_method,
+        command=found_command,
+        config_path=str(env.resolve(config_path)) if config_path else None,
+    )
+
+
+def select_harnesses(
+    spec: str, detections: list[HarnessDetection]
+) -> list[HarnessDetection]:
+    by_id = {detection.id: detection for detection in detections}
+    if spec == "auto":
+        return [detection for detection in detections if detection.detected]
+    if spec == "all":
+        return detections
+    requested = [item.strip() for item in spec.split(",") if item.strip()]
+    unknown = sorted(set(requested) - set(harness_ids()))
+    if unknown:
+        valid = ", ".join(harness_ids())
+        raise SystemExit(
+            f"Unknown client(s): {', '.join(unknown)}. Expected: auto, all, or one of {valid}."
+        )
+    return [by_id[item] for item in requested]
+
+
+def apply_harness_setup(
+    detection: HarnessDetection,
+    *,
+    repo_root: Path,
+    catalog: Path | None = None,
+    backend: str | None = None,
+    server_name: str = "skillroute",
+    mode: str = "prompt",
+    yes: bool = False,
+    install_mode: str = "mcp",
+) -> SetupResult:
+    if mode == "0":
+        return SetupResult(detection.id, "skipped", "client setup disabled")
+    payload = build_harness_setup(
+        harness=detection.id,
+        mode=install_mode,
+        repo_root=repo_root,
+        catalog=catalog,
+        backend=backend,
+        server_name=server_name,
+    )
+    if payload["setup_method"] == "print_only":
+        return SetupResult(
+            detection.id, "printed", json.dumps(payload["config"], indent=2, sort_keys=True)
+        )
+    if mode == "prompt" and not yes and not confirm(f"Set up {detection.name} for SkillRoute"):
+        return SetupResult(detection.id, "skipped", "user skipped setup")
+    if payload["setup_method"] == "command":
+        if not detection.detected:
+            return SetupResult(detection.id, "skipped", detection.reason)
+        command_parts = list(payload["install_command_parts"])
+        # Prefer the binary detection actually found: VS Code may only have
+        # `code-insiders`, and Homebrew installs land outside a bare name.
+        if detection.command:
+            command_parts[0] = detection.command
+        subprocess.run(command_parts, check=True)
+        return SetupResult(detection.id, "configured", payload["install_command"])
+    if detection.config_path is None:
+        return SetupResult(detection.id, "skipped", "no config path available")
+    backup_path = merge_json_config(Path(detection.config_path), payload["config"])
+    return SetupResult(
+        detection.id,
+        "configured",
+        f"wrote {detection.config_path}",
+        backup_path=str(backup_path) if backup_path else None,
+    )
+
+
+def merge_json_config(path: Path, incoming: dict[str, Any]) -> Path | None:
+    import datetime as dt
+
+    path = path.expanduser()
+    existing: dict[str, Any] = {}
+    backup_path: Path | None = None
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8") or "{}")
+        if not isinstance(existing, dict):
+            raise ValueError(f"Existing config is not a JSON object: {path}")
+        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d%H%M%S")
+        backup_path = path.with_name(f"{path.name}.bak-{timestamp}")
+        shutil.copy2(path, backup_path)
+
+    for key, value in incoming.items():
+        if isinstance(value, dict):
+            target = existing.setdefault(key, {})
+            if not isinstance(target, dict):
+                # ValueError, not TypeError: this is malformed on-disk data, not a caller bug
+                raise ValueError(f"Existing config field is not an object: {key}")  # noqa: TRY004
+            target.update(value)
+        else:
+            existing[key] = value
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return backup_path
+
+
+def confirm(prompt: str) -> bool:
+    try:
+        tty = open("/dev/tty", "r+", encoding="utf-8")  # noqa: SIM115 -- closed by `with tty:` below
+    except OSError as exc:
+        raise SystemExit(
+            "No terminal is available for prompts. Re-run with --yes or SKILLROUTE_CLIENT_SETUP=1."
+        ) from exc
+    with tty:
+        tty.write(f"? {prompt} [y/N] ")
+        tty.flush()
+        reply = tty.readline().strip().lower()
+    return reply in {"y", "yes"}
+
+
+def can_prompt() -> bool:
+    if os.isatty(0):
+        return True
+    try:
+        with open("/dev/tty", "r+", encoding="utf-8"):
+            return True
+    except OSError:
+        return False
+
+
+def print_detection_summary(detections: list[HarnessDetection]) -> None:
+    print("Detected agent clients:")
+    for detection in detections:
+        marker = "found" if detection.detected else "missing"
+        print(f"- {detection.name}: {marker} ({detection.reason})")
+
+
+def run_setup_command(args: argparse.Namespace) -> None:
+    env = HarnessEnvironment()
+    detections = detect_harnesses(env)
+    print_detection_summary(detections)
+    selected = select_harnesses(args.clients, detections)
+    if not selected:
+        print("No clients selected for setup.")
+        return
+    if args.mode == "prompt" and not args.yes and not can_prompt():
+        print(NO_TTY_SETUP_MESSAGE)
+        return
+    repo_root = args.repo_root.expanduser().resolve()
+    catalog = args.catalog.expanduser().resolve() if args.catalog else default_catalog_path(repo_root)
+    for detection in selected:
+        if args.clients == "auto" and not detection.detected:
+            continue
+        result = apply_harness_setup(
+            detection,
+            repo_root=repo_root,
+            catalog=catalog,
+            backend=args.backend,
+            yes=args.yes,
+            mode=args.mode,
+        )
+        print(f"{detection.name}: {result.status} - {result.message}")
+        if result.backup_path:
+            print(f"{detection.name}: backup - {result.backup_path}")
+
+
+def run_detect_command(args: argparse.Namespace) -> None:
+    detections = detect_harnesses(HarnessEnvironment())
+    if args.as_json:
+        print(json.dumps([asdict(detection) for detection in detections], indent=2, sort_keys=True))
+        return
+    print_detection_summary(detections)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m skillroute.harness_setup")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    detect_parser = subparsers.add_parser("detect", help="Detect supported harnesses")
+    detect_parser.add_argument("--json", action="store_true", dest="as_json")
+    detect_parser.set_defaults(func=run_detect_command)
+
+    setup_parser = subparsers.add_parser("setup", help="Detect and optionally configure harnesses")
+    setup_parser.add_argument("--repo-root", type=Path, required=True)
+    setup_parser.add_argument("--catalog", type=Path, default=None)
+    setup_parser.add_argument("--backend", default=None)
+    setup_parser.add_argument("--clients", default="auto")
+    setup_parser.add_argument("--mode", choices=SETUP_CHOICES, default="prompt")
+    setup_parser.add_argument("--yes", action="store_true")
+    setup_parser.set_defaults(func=run_setup_command)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/skillroute/harnesses.py
+++ b/src/skillroute/harnesses.py
@@ -1,0 +1,354 @@
+"""Declarative harness packs.
+
+A *harness* is an agent tool that can consume SkillRoute -- Claude Code, Codex,
+Pi, Hermes, OpenCode, and so on. v0.1 supported seven of them through a hardcoded
+if/elif chain plus a per-client ``detect_*`` function, so adding one meant
+editing about seven places across two modules and three docs.
+
+Here each harness is one TOML file under ``harnesses/``. The file declares how to
+detect the tool, where its config lives on each platform, and which install modes
+it supports. Adding a harness that fits an existing config shape is pure data;
+only a genuinely novel shape needs Python, and then only one named emitter plus
+its test.
+
+``tomllib`` is stdlib on 3.11+, and manifests are read-only at runtime, so this
+costs no dependency.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal
+
+MANIFEST_SCHEMA = 1
+
+Platform = Literal["macos", "linux", "windows"]
+PLATFORMS: tuple[Platform, ...] = ("macos", "linux", "windows")
+
+# Capability a harness can offer. `mcp` is the baseline every harness supports;
+# the rest are how a given tool prefers to be extended.
+INSTALL_MODES = ("mcp", "acp", "skills", "hook", "extension", "router_skill")
+
+# Mechanism used to apply a mode. Deliberately closed: `toml_merge` is absent
+# because SkillRoute never rewrites a user's TOML (tomllib cannot write, and
+# hand-merging someone's config.toml is not worth the blast radius). TOML-backed
+# harnesses use `command` or `print_only` instead.
+SETUP_METHODS = ("command", "json_merge", "print_only", "dir_sync", "package")
+
+TIERS = ("first-party", "breadth", "unverified")
+
+
+class ManifestError(ValueError):
+    """A harness manifest is malformed. Raised at load time, not at a user's terminal."""
+
+
+@dataclass(frozen=True, slots=True)
+class Detect:
+    commands: tuple[str, ...] = ()
+    # MCP `initialize` clientInfo.name values that mean "this harness".
+    client_names: tuple[str, ...] = ()
+    env: tuple[str, ...] = ()
+    paths: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    apps: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def paths_for(self, platform: str) -> tuple[str, ...]:
+        return self.paths.get(platform, ()) + self.paths.get("all", ())
+
+    def apps_for(self, platform: str) -> tuple[str, ...]:
+        return self.apps.get(platform, ()) + self.apps.get("all", ())
+
+
+@dataclass(frozen=True, slots=True)
+class InstallMode:
+    mode: str
+    setup_method: str
+    # Human-facing location, shown in `harness show` output. Deliberately
+    # separate from write_path: several harnesses display something like
+    # "~/.bob/mcp.json or .bob/mcp.json" that is not a single real path.
+    config_path_display: str = ""
+    config_format: str = "json"
+    emitter: str = ""
+    argv: tuple[str, ...] = ()
+    # Real per-platform path SkillRoute reads or writes. Keys are platforms or "all".
+    write_path: dict[str, str] = field(default_factory=dict)
+    # Per-scope overrides, e.g. Claude Code's project scope writing .mcp.json.
+    scope_paths: dict[str, str] = field(default_factory=dict)
+    scopes: tuple[str, ...] = ()
+    default_scope: str = ""
+    # Extra literal keys folded into the emitted server config (cwd, disabled,
+    # startup_timeout_sec, ...). This is what absorbs most per-harness quirk.
+    extra: dict[str, Any] = field(default_factory=dict)
+    # Directories SkillRoute can read skills from, for `skills` mode.
+    skills_dirs: dict[str, str] = field(default_factory=dict)
+    project_dir: str = ""
+    discovery: tuple[str, ...] = ()
+    # Some harnesses let you register an extra skills directory instead of
+    # copying files into theirs. Registration beats sync: no duplication, no drift.
+    register_in: dict[str, str] = field(default_factory=dict)
+    notes: tuple[str, ...] = ()
+
+    def path_for(self, platform: str, scope: str = "") -> str:
+        if scope and scope in self.scope_paths:
+            return self.scope_paths[scope]
+        return self.write_path.get(platform) or self.write_path.get("all", "")
+
+    def skills_dir_for(self, platform: str) -> str:
+        return self.skills_dirs.get(platform) or self.skills_dirs.get("all", "")
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessManifest:
+    id: str
+    display_name: str
+    tier: str
+    homepage: str
+    detect: Detect
+    modes: dict[str, InstallMode]
+    notes: tuple[str, ...] = ()
+
+    def mode(self, name: str) -> InstallMode | None:
+        return self.modes.get(name)
+
+    def supports(self, name: str) -> bool:
+        return name in self.modes
+
+
+def default_manifest_root() -> Path:
+    """Locate ``harnesses/`` in a wheel install or a source checkout.
+
+    Mirrors how ``ui_server.default_web_dist()`` resolves bundled assets.
+    """
+    override = os.environ.get("SKILLROUTE_HARNESS_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    packaged = Path(__file__).resolve().parent / "_harnesses"
+    if packaged.is_dir():
+        return packaged
+    return Path(__file__).resolve().parents[2] / "harnesses"
+
+
+def current_platform() -> Platform:
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("win"):
+        return "windows"
+    return "linux"
+
+
+@lru_cache(maxsize=8)
+def load_manifests(root: Path | None = None) -> dict[str, HarnessManifest]:
+    """Parse every ``harnesses/*.toml``, keyed by harness id.
+
+    Cached because the CLI, the bridge, and the UI server all load these and the
+    files never change within a process.
+    """
+    manifest_root = root or default_manifest_root()
+    manifests: dict[str, HarnessManifest] = {}
+    if not manifest_root.is_dir():
+        return manifests
+    for path in sorted(manifest_root.glob("*.toml")):
+        with path.open("rb") as handle:
+            raw = tomllib.load(handle)
+        manifest = parse_manifest(raw, source=path)
+        if manifest.id != path.stem:
+            raise ManifestError(f"{path}: id {manifest.id!r} does not match filename stem")
+        manifests[manifest.id] = manifest
+    return manifests
+
+
+def parse_manifest(raw: dict[str, Any], *, source: Path | str = "<memory>") -> HarnessManifest:
+    schema = raw.get("schema")
+    if schema != MANIFEST_SCHEMA:
+        raise ManifestError(f"{source}: schema must be {MANIFEST_SCHEMA}, got {schema!r}")
+    for key in ("id", "display_name"):
+        if not isinstance(raw.get(key), str) or not raw[key].strip():
+            raise ManifestError(f"{source}: missing required string field {key!r}")
+    tier = raw.get("tier", "breadth")
+    if tier not in TIERS:
+        raise ManifestError(f"{source}: tier {tier!r} must be one of {', '.join(TIERS)}")
+
+    detect_raw = raw.get("detect", {})
+    if not isinstance(detect_raw, dict):
+        raise ManifestError(f"{source}: [detect] must be a table")
+    detect = Detect(
+        commands=_str_tuple(detect_raw.get("commands"), source, "detect.commands"),
+        client_names=_str_tuple(detect_raw.get("client_names"), source, "detect.client_names"),
+        env=_str_tuple(detect_raw.get("env"), source, "detect.env"),
+        paths=_platform_lists(detect_raw.get("paths"), source, "detect.paths"),
+        apps=_platform_lists(detect_raw.get("apps"), source, "detect.apps"),
+    )
+
+    modes_raw = raw.get("modes", {})
+    if not isinstance(modes_raw, dict):
+        raise ManifestError(f"{source}: [modes] must be a table")
+    modes: dict[str, InstallMode] = {}
+    for mode_name, mode_raw in modes_raw.items():
+        if mode_name not in INSTALL_MODES:
+            raise ManifestError(
+                f"{source}: unknown install mode {mode_name!r}; "
+                f"expected one of {', '.join(INSTALL_MODES)}"
+            )
+        if not isinstance(mode_raw, dict):
+            raise ManifestError(f"{source}: [modes.{mode_name}] must be a table")
+        modes[mode_name] = _parse_mode(mode_name, mode_raw, source)
+
+    return HarnessManifest(
+        id=raw["id"],
+        display_name=raw["display_name"],
+        tier=tier,
+        homepage=str(raw.get("homepage", "")),
+        detect=detect,
+        modes=modes,
+        notes=_str_tuple(raw.get("notes"), source, "notes"),
+    )
+
+
+def _parse_mode(mode_name: str, raw: dict[str, Any], source: Path | str) -> InstallMode:
+    setup_method = raw.get("setup_method", "")
+    if setup_method not in SETUP_METHODS:
+        raise ManifestError(
+            f"{source}: [modes.{mode_name}] setup_method {setup_method!r} must be one of "
+            f"{', '.join(SETUP_METHODS)}"
+        )
+    scopes = _str_tuple(raw.get("scopes"), source, f"modes.{mode_name}.scopes")
+    default_scope = str(raw.get("default_scope", ""))
+    if scopes and default_scope and default_scope not in scopes:
+        raise ManifestError(
+            f"{source}: [modes.{mode_name}] default_scope {default_scope!r} is not in scopes"
+        )
+    if setup_method == "command" and not raw.get("argv"):
+        raise ManifestError(f"{source}: [modes.{mode_name}] setup_method=command requires argv")
+    return InstallMode(
+        mode=mode_name,
+        setup_method=setup_method,
+        config_path_display=str(raw.get("config_path", "")),
+        config_format=str(raw.get("config_format", "json")),
+        emitter=str(raw.get("emitter", "")),
+        argv=_str_tuple(raw.get("argv"), source, f"modes.{mode_name}.argv"),
+        write_path=_platform_strings(
+            raw.get("write_path"), source, f"modes.{mode_name}.write_path"
+        ),
+        scope_paths=_string_map(raw.get("scope_paths"), source, f"modes.{mode_name}.scope_paths"),
+        scopes=scopes,
+        default_scope=default_scope,
+        extra=dict(raw.get("extra", {})),
+        skills_dirs=_platform_strings(raw.get("dir"), source, f"modes.{mode_name}.dir"),
+        project_dir=str(raw.get("project_dir", "")),
+        discovery=_str_tuple(raw.get("discovery"), source, f"modes.{mode_name}.discovery"),
+        register_in=_string_map(
+            raw.get("register_in"), source, f"modes.{mode_name}.register_in"
+        ),
+        notes=_str_tuple(raw.get("notes"), source, f"modes.{mode_name}.notes"),
+    )
+
+
+def _str_tuple(value: Any, source: Path | str, label: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ManifestError(f"{source}: {label} must be a list of strings")
+    return tuple(value)
+
+
+def _platform_lists(
+    value: Any, source: Path | str, label: str
+) -> dict[str, tuple[str, ...]]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ManifestError(f"{source}: {label} must be a table keyed by platform")
+    result: dict[str, tuple[str, ...]] = {}
+    for key, items in value.items():
+        _check_platform_key(key, source, label)
+        result[key] = _str_tuple(items, source, f"{label}.{key}")
+    return result
+
+
+def _platform_strings(value: Any, source: Path | str, label: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ManifestError(f"{source}: {label} must be a table keyed by platform")
+    result: dict[str, str] = {}
+    for key, item in value.items():
+        _check_platform_key(key, source, label)
+        if not isinstance(item, str):
+            raise ManifestError(f"{source}: {label}.{key} must be a string")
+        result[key] = item
+    return result
+
+
+def _string_map(value: Any, source: Path | str, label: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict) or not all(
+        isinstance(item, str) for item in value.values()
+    ):
+        raise ManifestError(f"{source}: {label} must be a table of strings")
+    return dict(value)
+
+
+def _check_platform_key(key: str, source: Path | str, label: str) -> None:
+    if key != "all" and key not in PLATFORMS:
+        raise ManifestError(
+            f"{source}: {label} key {key!r} must be 'all' or one of {', '.join(PLATFORMS)}"
+        )
+
+
+# --- lookups -------------------------------------------------------------
+
+
+def harness_ids(root: Path | None = None) -> tuple[str, ...]:
+    return tuple(load_manifests(root))
+
+
+def manifest_for(harness: str, root: Path | None = None) -> HarnessManifest:
+    manifests = load_manifests(root)
+    if harness not in manifests:
+        valid = ", ".join(sorted(manifests))
+        raise ValueError(f"Unsupported harness {harness!r}; expected one of: {valid}")
+    return manifests[harness]
+
+
+def harness_for_client_name(name: str, root: Path | None = None) -> str | None:
+    """Map an MCP ``clientInfo.name`` onto a harness id.
+
+    Matching is case-insensitive and accepts the glob patterns manifests declare,
+    because clients report names like ``claude-code`` and ``Claude Code`` and
+    sometimes append a channel suffix.
+    """
+    if not name:
+        return None
+    needle = name.strip().casefold()
+    for harness_id, manifest in load_manifests(root).items():
+        for candidate in manifest.detect.client_names:
+            pattern = candidate.casefold()
+            if needle == pattern or fnmatch.fnmatch(needle, pattern):
+                return harness_id
+    return None
+
+
+def skill_discovery_globs(
+    root: Path | None = None, platform: str | None = None
+) -> tuple[str, ...]:
+    """Every skills directory any known harness reads from.
+
+    Replaces ``dogfood.DEFAULT_SKILL_ROOTS``, which was a hardcoded three-entry
+    tuple that notably did not include ``.claude/skills``.
+    """
+    resolved = platform or current_platform()
+    globs: list[str] = []
+    for manifest in load_manifests(root).values():
+        mode = manifest.mode("skills")
+        if mode is None:
+            continue
+        for candidate in (mode.skills_dir_for(resolved), *mode.discovery):
+            if candidate and candidate not in globs:
+                globs.append(candidate)
+    return tuple(globs)

--- a/src/skillroute/mcp_setup.py
+++ b/src/skillroute/mcp_setup.py
@@ -1,24 +1,50 @@
+"""Deprecated compatibility shim over the harness pack engine.
+
+v0.1 called these tools "clients" and built their config with a hand-written
+if/elif chain. 0.2 calls them *harnesses* and declares them in
+``harnesses/*.toml``; see :mod:`skillroute.harnesses` and
+:mod:`skillroute.harness_render`.
+
+Everything here forwards to the new engine and produces identical output --
+``tests/test_harness_render.py`` asserts that byte-for-byte for every harness
+and scope. This module exists so pre-0.2 callers keep working for one release,
+and will be removed in 0.3.
+"""
+
 from __future__ import annotations
 
-import json
-import os
-import re
-import shlex
 from pathlib import Path
 from typing import Any
 
-from skillroute.catalog import default_catalog_path
-
-MCP_CLIENT_CHOICES = (
-    "ibm-bob",
-    "codex",
-    "claude-code",
-    "claude-desktop",
-    "vscode",
-    "windsurf",
-    "cursor",
+from skillroute.harness_render import (
+    build_harness_setup,
+    default_repo_root,
+    harness_display_name,
+    render_harness_setup,
+    shell_command,
 )
+from skillroute.harnesses import harness_ids, manifest_for
+
+__all__ = [
+    "CLAUDE_SCOPE_CHOICES",
+    "MCP_CLIENT_CHOICES",
+    "build_mcp_setup",
+    "client_display_name",
+    "default_repo_root",
+    "render_mcp_setup",
+    "shell_command",
+]
+
 CLAUDE_SCOPE_CHOICES = ("local", "project", "user")
+
+
+def _client_choices() -> tuple[str, ...]:
+    return harness_ids()
+
+
+# Kept as a module-level name because callers (and the CLI's argparse choices)
+# read it directly. Ordered to match the manifests on disk.
+MCP_CLIENT_CHOICES: tuple[str, ...] = _client_choices()
 
 
 def build_mcp_setup(
@@ -30,271 +56,36 @@ def build_mcp_setup(
     server_name: str = "skillroute",
     claude_scope: str = "user",
 ) -> dict[str, Any]:
+    """Deprecated. Use ``harness_render.build_harness_setup`` instead."""
     if client not in MCP_CLIENT_CHOICES:
         valid = ", ".join(MCP_CLIENT_CHOICES)
         raise ValueError(f"Unsupported MCP client {client!r}; expected one of: {valid}")
     if claude_scope not in CLAUDE_SCOPE_CHOICES:
         valid = ", ".join(CLAUDE_SCOPE_CHOICES)
-        raise ValueError(f"Unsupported Claude Code scope {claude_scope!r}; expected one of: {valid}")
-
-    resolved_repo_root = (repo_root or default_repo_root()).expanduser().resolve()
-    catalog_path = (catalog.expanduser().resolve() if catalog else default_catalog_path(resolved_repo_root))
-    selected_backend = (backend or os.environ.get("SKILLROUTE_BACKEND") or "local").strip().lower()
-    entrypoint = resolved_repo_root / "mcp" / "build" / "index.js"
-    env = {
-        "SKILLROUTE_CATALOG_PATH": str(catalog_path),
-        "SKILLROUTE_BACKEND": selected_backend,
-    }
-    stdio_server_config = {
-        "command": "node",
-        "args": [str(entrypoint)],
-        "env": env,
-    }
-    notes = [
-        "Run ./scripts/bootstrap.sh first if mcp/build/index.js does not exist.",
-        "The generated config points at this local checkout and catalog.",
-    ]
-    if not entrypoint.exists():
-        notes.append(f"MCP entrypoint not found yet: {entrypoint}")
-
-    payload: dict[str, Any] = {
-        "client": client,
-        "server_name": server_name,
-        "repo_root": str(resolved_repo_root),
-        "mcp_entrypoint": str(entrypoint),
-        "catalog": str(catalog_path),
-        "backend": selected_backend,
-        "server_config": stdio_server_config,
-        "notes": notes,
-    }
-
-    if client == "ibm-bob":
-        payload.update(
-            {
-                "install_command": None,
-                "install_command_parts": None,
-                "config_path": "~/.bob/mcp.json or .bob/mcp.json",
-                "config_format": "json",
-                "setup_method": "json_merge",
-                "config": {
-                    "mcpServers": {
-                        server_name: {
-                            **stdio_server_config,
-                            "cwd": str(resolved_repo_root),
-                            "disabled": False,
-                        }
-                    }
-                },
-            }
+        raise ValueError(
+            f"Unsupported Claude Code scope {claude_scope!r}; expected one of: {valid}"
         )
-    elif client == "codex":
-        command_parts = codex_command_parts(server_name, catalog_path, selected_backend, entrypoint)
-        payload.update(
-            {
-                "install_command": shell_command(command_parts),
-                "install_command_parts": command_parts,
-                "config_path": "~/.codex/config.toml",
-                "config_format": "toml",
-                "setup_method": "command",
-                "config": codex_toml(server_name, entrypoint, resolved_repo_root, env),
-            }
-        )
-    elif client == "claude-code":
-        command_parts = claude_code_command_parts(
-            server_name,
-            catalog_path,
-            selected_backend,
-            entrypoint,
-            claude_scope,
-        )
-        payload.update(
-            {
-                "scope": claude_scope,
-                "install_command": shell_command(command_parts),
-                "install_command_parts": command_parts,
-                "config_path": claude_code_config_path(claude_scope),
-                "config_format": "json",
-                "setup_method": "command",
-                "config": {"mcpServers": {server_name: stdio_server_config}},
-            }
-        )
-    elif client == "claude-desktop":
-        payload.update(
-            {
-                "install_command": None,
-                "install_command_parts": None,
-                "config_path": (
-                    "~/Library/Application Support/Claude/claude_desktop_config.json "
-                    "or %APPDATA%\\Claude\\claude_desktop_config.json"
-                ),
-                "config_format": "json",
-                "setup_method": "json_merge",
-                "config": {"mcpServers": {server_name: stdio_server_config}},
-            }
-        )
-    elif client == "vscode":
-        server_config = {"name": server_name, **stdio_server_config}
-        command_parts = ["code", "--add-mcp", json.dumps(server_config, sort_keys=True)]
-        payload.update(
-            {
-                "install_command": shell_command(command_parts),
-                "install_command_parts": command_parts,
-                "config_path": "VS Code user profile mcp.json",
-                "config_format": "json",
-                "setup_method": "command",
-                "config": {"servers": {server_name: stdio_server_config}},
-                "server_config": server_config,
-            }
-        )
-    elif client == "windsurf":
-        payload.update(
-            {
-                "install_command": None,
-                "install_command_parts": None,
-                "config_path": "~/.codeium/windsurf/mcp_config.json",
-                "config_format": "json",
-                "setup_method": "json_merge",
-                "config": {"mcpServers": {server_name: stdio_server_config}},
-            }
-        )
-    else:
-        payload.update(
-            {
-                "install_command": None,
-                "install_command_parts": None,
-                "config_path": "Cursor MCP settings",
-                "config_format": "json",
-                "setup_method": "print_only",
-                "config": {"mcpServers": {server_name: stdio_server_config}},
-                "notes": [
-                    *payload["notes"],
-                    "Cursor setup is snippet-only until a stable official write target is confirmed.",
-                ],
-            }
-        )
-
-    return payload
-
-
-def default_repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def shell_command(parts: list[str]) -> str:
-    return shlex.join(parts)
-
-
-def codex_command_parts(
-    server_name: str,
-    catalog_path: Path,
-    selected_backend: str,
-    entrypoint: Path,
-) -> list[str]:
-    return [
-        "codex",
-        "mcp",
-        "add",
-        server_name,
-        "--env",
-        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
-        "--env",
-        f"SKILLROUTE_BACKEND={selected_backend}",
-        "--",
-        "node",
-        str(entrypoint),
-    ]
-
-
-def claude_code_command_parts(
-    server_name: str,
-    catalog_path: Path,
-    selected_backend: str,
-    entrypoint: Path,
-    claude_scope: str,
-) -> list[str]:
-    return [
-        "claude",
-        "mcp",
-        "add",
-        "--transport",
-        "stdio",
-        "--scope",
-        claude_scope,
-        "--env",
-        f"SKILLROUTE_CATALOG_PATH={catalog_path}",
-        "--env",
-        f"SKILLROUTE_BACKEND={selected_backend}",
-        server_name,
-        "--",
-        "node",
-        str(entrypoint),
-    ]
-
-
-def codex_toml(server_name: str, entrypoint: Path, repo_root: Path, env: dict[str, str]) -> str:
-    args = ", ".join(toml_string(part) for part in [str(entrypoint)])
-    env_pairs = ", ".join(f"{key} = {toml_string(value)}" for key, value in sorted(env.items()))
-    table_name = toml_table_name(server_name)
-    return "\n".join(
-        [
-            f"[mcp_servers.{table_name}]",
-            'command = "node"',
-            f"args = [{args}]",
-            f"cwd = {toml_string(str(repo_root))}",
-            f"env = {{ {env_pairs} }}",
-            "startup_timeout_sec = 20",
-            "tool_timeout_sec = 60",
-        ]
+    # Only harnesses that actually declare scopes accept one; passing the
+    # default through unconditionally would reject every other harness.
+    manifest = manifest_for(client)
+    mode = manifest.mode("mcp")
+    scope = claude_scope if mode is not None and mode.scopes else None
+    return build_harness_setup(
+        harness=client,
+        mode="mcp",
+        repo_root=repo_root,
+        catalog=catalog,
+        backend=backend,
+        server_name=server_name,
+        scope=scope,
     )
 
 
-def claude_code_config_path(scope: str) -> str:
-    if scope == "project":
-        return ".mcp.json"
-    return "~/.claude.json"
-
-
-def toml_table_name(value: str) -> str:
-    if re.fullmatch(r"[A-Za-z0-9_-]+", value):
-        return value
-    return toml_string(value)
-
-
-def toml_string(value: str) -> str:
-    return json.dumps(value)
-
-
 def render_mcp_setup(payload: dict[str, Any]) -> str:
-    lines = [
-        f"SkillRoute MCP setup for {client_display_name(payload['client'])}",
-        f"server: {payload['server_name']}",
-        f"catalog: {payload['catalog']}",
-        f"backend: {payload['backend']}",
-        "",
-    ]
-    if payload.get("install_command"):
-        lines.extend(["Install command:", payload["install_command"], ""])
-    lines.extend([f"Config path: {payload['config_path']}", f"Config format: {payload['config_format']}", ""])
-    lines.append("Config snippet:")
-    config = payload["config"]
-    if isinstance(config, str):
-        lines.append(config)
-    else:
-        lines.append(json.dumps(config, indent=2, sort_keys=True))
-    if payload.get("notes"):
-        lines.extend(["", "Notes:"])
-        lines.extend(f"- {note}" for note in payload["notes"])
-    return "\n".join(lines)
+    """Deprecated. Use ``harness_render.render_harness_setup`` instead."""
+    return render_harness_setup(payload)
 
 
 def client_display_name(client: str) -> str:
-    names = {
-        "ibm-bob": "IBM Bob",
-        "codex": "Codex",
-        "claude-code": "Claude Code",
-        "claude-desktop": "Claude Desktop",
-        "vscode": "VS Code",
-        "cursor": "Cursor",
-        "windsurf": "Windsurf",
-    }
-    return names.get(client, client)
+    """Deprecated. Use ``harness_render.harness_display_name`` instead."""
+    return harness_display_name(client)

--- a/src/skillroute/migrations.py
+++ b/src/skillroute/migrations.py
@@ -1,0 +1,327 @@
+"""Schema migrations for the SkillRoute catalog.
+
+The catalog is a plain SQLite file users keep across upgrades, so schema changes
+need a forward path rather than a rebuild. Each :class:`Migration` moves the
+database from ``version - 1`` to ``version``; :func:`apply_pending` runs the ones
+a given database has not seen yet, in order, inside the caller's transaction.
+
+A *fresh* catalog never runs migrations -- ``Catalog.initialize()`` creates the
+current shape directly from ``CREATE_SCHEMA_SQL`` and stamps the version. That
+means the DDL exists twice: once as the current shape, once as the steps to get
+there. ``tests/test_migrations.py`` guards the duplication by asserting a freshly
+created database and a migrated one end up with identical ``sqlite_master``.
+
+Adding a migration means appending one entry to :data:`MIGRATIONS`, updating
+``CREATE_SCHEMA_SQL``, and bumping ``catalog.SCHEMA_VERSION``. Never edit a
+released migration in place -- databases in the wild have already applied it.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# --- v2 -----------------------------------------------------------------
+#
+# Promotes the fields analytics needs out of the two opaque JSON blobs a v1
+# trace stored, and adds the tables that make routing measurable: denormalized
+# candidates, reported outcomes, multi-step plans, a daily rollup that outlives
+# trace pruning, catalog snapshots for change-over-time, and the cached 2D
+# projection.
+
+V2_TRACE_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("trace_uid", "TEXT"),
+    ("harness_id", "TEXT"),
+    ("harness_version", "TEXT"),
+    ("surface", "TEXT"),
+    ("request_text", "TEXT"),
+    ("backend", "TEXT"),
+    ("repo_path", "TEXT"),
+    ("top_skill_id", "TEXT"),
+    ("top_confidence", "REAL"),
+    ("second_confidence", "REAL"),
+    ("candidate_count", "INTEGER"),
+    ("clarification_needed", "INTEGER"),
+    ("plan_id", "TEXT"),
+    ("subtask_index", "INTEGER"),
+    ("subtask_text", "TEXT"),
+    ("catalog_fingerprint", "TEXT"),
+    ("weights_json", "TEXT"),
+)
+
+V2_TABLES_SQL = """
+CREATE TABLE IF NOT EXISTS route_trace_candidates (
+    trace_id INTEGER NOT NULL REFERENCES route_traces(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    skill_id TEXT NOT NULL,
+    content_hash TEXT NOT NULL DEFAULT '',
+    name TEXT NOT NULL DEFAULT '',
+    confidence REAL NOT NULL DEFAULT 0,
+    lexical REAL NOT NULL DEFAULT 0,
+    semantic REAL NOT NULL DEFAULT 0,
+    repo_context REAL NOT NULL DEFAULT 0,
+    graph REAL NOT NULL DEFAULT 0,
+    total REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (trace_id, position)
+);
+
+CREATE TABLE IF NOT EXISTS route_outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trace_uid TEXT NOT NULL,
+    skill_id TEXT,
+    used INTEGER NOT NULL DEFAULT 0,
+    helpful INTEGER,
+    rank_used INTEGER,
+    harness_id TEXT,
+    note TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS route_plans (
+    plan_id TEXT PRIMARY KEY,
+    request TEXT NOT NULL,
+    harness_id TEXT,
+    surface TEXT,
+    subtask_count INTEGER NOT NULL DEFAULT 0,
+    gap_count INTEGER NOT NULL DEFAULT 0,
+    response_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS route_trace_daily (
+    day TEXT NOT NULL,
+    harness_id TEXT NOT NULL DEFAULT '',
+    route_count INTEGER NOT NULL DEFAULT 0,
+    clarification_count INTEGER NOT NULL DEFAULT 0,
+    confidence_sum REAL NOT NULL DEFAULT 0,
+    confidence_min REAL,
+    confidence_max REAL,
+    histogram_json TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (day, harness_id)
+);
+
+CREATE TABLE IF NOT EXISTS catalog_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fingerprint TEXT NOT NULL,
+    label TEXT,
+    skill_count INTEGER NOT NULL DEFAULT 0,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS skill_projection (
+    fingerprint TEXT NOT NULL,
+    skill_id TEXT NOT NULL,
+    x REAL NOT NULL,
+    y REAL NOT NULL,
+    method TEXT NOT NULL DEFAULT 'hashed-pca',
+    PRIMARY KEY (fingerprint, skill_id)
+);
+"""
+
+V2_INDEXES_SQL = """
+CREATE UNIQUE INDEX IF NOT EXISTS idx_traces_uid ON route_traces(trace_uid);
+CREATE INDEX IF NOT EXISTS idx_traces_created ON route_traces(created_at);
+CREATE INDEX IF NOT EXISTS idx_traces_harness_created
+    ON route_traces(harness_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_traces_top_skill ON route_traces(top_skill_id);
+CREATE INDEX IF NOT EXISTS idx_traces_plan ON route_traces(plan_id, subtask_index);
+CREATE INDEX IF NOT EXISTS idx_trace_candidates_skill
+    ON route_trace_candidates(skill_id);
+CREATE INDEX IF NOT EXISTS idx_outcomes_uid ON route_outcomes(trace_uid);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_snapshot_label
+    ON catalog_snapshots(fingerprint, label);
+"""
+
+
+class CatalogVersionError(RuntimeError):
+    """Raised when a catalog was written by a newer SkillRoute than this one."""
+
+
+@dataclass(frozen=True, slots=True)
+class Migration:
+    version: int
+    name: str
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def migrate_v2(connection: sqlite3.Connection) -> None:
+    for column, column_type in V2_TRACE_COLUMNS:
+        _add_column(connection, "route_traces", column, column_type)
+    connection.executescript(V2_TABLES_SQL)
+    _backfill_v2_traces(connection)
+    # Indexes come last: idx_traces_uid is UNIQUE, and every pre-existing row
+    # needs its trace_uid populated by the backfill before it can be enforced.
+    connection.executescript(V2_INDEXES_SQL)
+
+
+def _backfill_v2_traces(connection: sqlite3.Connection) -> None:
+    """Unpack v1 JSON blobs into the promoted columns and candidate rows.
+
+    Pre-0.2 traces stored everything as two opaque JSON documents. Analytics
+    queries columns, so existing history is unpacked once here instead of being
+    discarded. ``harness_id`` stays NULL for these rows -- v1 never recorded a
+    caller -- and readers render that as "unknown".
+
+    Best effort per row: a trace whose JSON is unreadable is skipped with a
+    warning rather than failing the upgrade and locking the user out of their
+    catalog.
+    """
+    rows = connection.execute(
+        "SELECT id, request_json, response_json FROM route_traces ORDER BY id"
+    ).fetchall()
+    skipped = 0
+    for row in rows:
+        try:
+            request = json.loads(row["request_json"])
+            response = json.loads(row["response_json"])
+        except (json.JSONDecodeError, TypeError, ValueError):
+            skipped += 1
+            continue
+        if not isinstance(request, dict) or not isinstance(response, dict):
+            skipped += 1
+            continue
+
+        raw_candidates = response.get("candidates")
+        candidates = [item for item in raw_candidates if isinstance(item, dict)] if (
+            isinstance(raw_candidates, list)
+        ) else []
+        confidences = [_as_float(item.get("confidence")) for item in candidates]
+        connection.execute(
+            """
+            UPDATE route_traces
+            SET trace_uid = ?,
+                surface = ?,
+                request_text = ?,
+                backend = ?,
+                repo_path = ?,
+                top_skill_id = ?,
+                top_confidence = ?,
+                second_confidence = ?,
+                candidate_count = ?,
+                clarification_needed = ?
+            WHERE id = ?
+            """,
+            (
+                uuid.uuid4().hex,
+                "legacy",
+                _as_text(request.get("request") or response.get("request")),
+                _as_text(request.get("backend")),
+                _as_text(request.get("repo")),
+                _as_text(candidates[0].get("skill_id")) if candidates else None,
+                confidences[0] if confidences else None,
+                confidences[1] if len(confidences) > 1 else None,
+                len(candidates),
+                int(bool(response.get("clarification_needed"))),
+                row["id"],
+            ),
+        )
+        for position, candidate in enumerate(candidates, start=1):
+            raw_breakdown = candidate.get("score_breakdown")
+            breakdown = raw_breakdown if isinstance(raw_breakdown, dict) else {}
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO route_trace_candidates (
+                    trace_id, position, skill_id, content_hash, name, confidence,
+                    lexical, semantic, repo_context, graph, total
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["id"],
+                    position,
+                    _as_text(candidate.get("skill_id")) or "",
+                    _as_text(candidate.get("content_hash")) or "",
+                    _as_text(candidate.get("name")) or "",
+                    _as_float(candidate.get("confidence")),
+                    _as_float(breakdown.get("lexical")),
+                    _as_float(breakdown.get("semantic")),
+                    _as_float(breakdown.get("repo_context")),
+                    _as_float(breakdown.get("graph")),
+                    _as_float(breakdown.get("total")),
+                ),
+            )
+    if skipped:
+        print(
+            f"skillroute: skipped {skipped} unreadable route trace(s) during schema upgrade",
+            file=sys.stderr,
+        )
+
+
+def _as_float(value: object) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_text(value: object) -> str | None:
+    return None if value is None else str(value)
+
+
+def _add_column(
+    connection: sqlite3.Connection, table: str, column: str, column_type: str
+) -> None:
+    """Add a column, tolerating one that is already present.
+
+    SQLite has no ``ADD COLUMN IF NOT EXISTS``, and a partially-upgraded
+    database (a migration interrupted before its version was stamped) would
+    otherwise be unrecoverable. Any other OperationalError is a real problem and
+    propagates.
+    """
+    try:
+        connection.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_type}")
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+
+
+MIGRATIONS: tuple[Migration, ...] = (
+    Migration(version=2, name="trace_analytics", apply=migrate_v2),
+)
+
+
+def detect_schema_version(connection: sqlite3.Connection) -> int:
+    """Return the on-disk schema version.
+
+    Three cases matter, and the middle one is why this cannot just read the
+    version table: a v1 catalog predates nothing, but a database with no tables
+    at all is *fresh* rather than v0-needing-migration.
+    """
+    if not _table_exists(connection, "skills"):
+        return 0
+    if not _table_exists(connection, "schema_version"):
+        # Tables but no version row: a v1 catalog from before versioning landed.
+        return 1
+    row = connection.execute("SELECT MAX(version) FROM schema_version").fetchone()
+    version = row[0] if row else None
+    return int(version) if version is not None else 1
+
+
+def _table_exists(connection: sqlite3.Connection, name: str) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def pending_migrations(current: int) -> tuple[Migration, ...]:
+    return tuple(migration for migration in MIGRATIONS if migration.version > current)
+
+
+def apply_pending(connection: sqlite3.Connection, current: int) -> int:
+    """Apply every migration newer than ``current`` and return the new version.
+
+    Runs inside the caller's transaction, so a failure part-way leaves the
+    database at its original version rather than half-upgraded.
+    """
+    version = current
+    for migration in pending_migrations(current):
+        migration.apply(connection)
+        version = migration.version
+    return version

--- a/src/skillroute/routing.py
+++ b/src/skillroute/routing.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
+from skillroute.attribution import Attribution
 from skillroute.backends import LocalTokenBackend, RetrievalBackend
 from skillroute.catalog import Catalog
 from skillroute.context import collect_repo_context
@@ -103,6 +104,7 @@ class Router:
         limit: int = 5,
         *,
         record_trace: bool = True,
+        attribution: Attribution | None = None,
     ) -> RouteResponse:
         repo_path = Path(repo).expanduser() if repo else None
         repo_context = collect_repo_context(repo_path)
@@ -131,6 +133,8 @@ class Router:
                     "backend": self.backend.name,
                 },
                 response,
+                attribution=attribution,
+                weights=self.weights.to_json(),
             )
         return response
 

--- a/tests/fixtures/schema_v1.sql
+++ b/tests/fixtures/schema_v1.sql
@@ -1,0 +1,66 @@
+-- The v0.1.0 catalog schema, verbatim.
+--
+-- Committed as reviewable SQL rather than a binary .db so the migration tests
+-- exercise a real pre-0.2 database that a reader can actually inspect. Do not
+-- edit this file to match schema changes -- it is a historical record of what
+-- shipped, and editing it would make the migration tests stop testing anything.
+
+CREATE TABLE schema_version (
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE skills (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    skill_path TEXT NOT NULL,
+    bundle_path TEXT NOT NULL,
+    root_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    metadata_json TEXT NOT NULL,
+    tags_json TEXT NOT NULL,
+    facets_json TEXT NOT NULL,
+    references_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE excerpts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    text TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL
+);
+
+CREATE TABLE relationships (
+    from_skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    to_ref TEXT NOT NULL,
+    PRIMARY KEY (from_skill_id, type, to_ref)
+);
+
+CREATE TABLE backend_index_refs (
+    skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    backend TEXT NOT NULL,
+    ref TEXT NOT NULL,
+    status TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (skill_id, backend)
+);
+
+CREATE TABLE route_traces (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_json TEXT NOT NULL,
+    response_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_skills_name ON skills(name);
+CREATE INDEX idx_skills_root ON skills(root_path);
+CREATE INDEX idx_excerpts_skill ON excerpts(skill_id);
+CREATE INDEX idx_backend_refs_skill ON backend_index_refs(skill_id);
+
+INSERT INTO schema_version(version) VALUES (1);

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skillroute.attribution import Attribution, resolve_attribution
+from skillroute.catalog import Catalog
+from skillroute.cli import main
+from skillroute.routing import Router
+
+
+def test_explicit_wins_over_everything() -> None:
+    attribution = resolve_attribution(
+        explicit="pi",
+        client_name="claude-code",
+        environ={"SKILLROUTE_HARNESS": "codex"},
+        surface="mcp",
+    )
+    assert attribution.harness_id == "pi"
+    assert attribution.surface == "mcp"
+
+
+def test_client_name_is_mapped_through_the_lookup() -> None:
+    attribution = resolve_attribution(
+        client_name="claude-code",
+        client_name_lookup={"claude-code": "claude-code"}.get,
+        environ={"SKILLROUTE_HARNESS": "codex"},
+        surface="mcp",
+    )
+    assert attribution.harness_id == "claude-code"
+
+
+def test_unmapped_client_name_falls_through_to_env() -> None:
+    attribution = resolve_attribution(
+        client_name="some-unknown-editor",
+        client_name_lookup={}.get,
+        environ={"SKILLROUTE_HARNESS": "codex"},
+        surface="mcp",
+    )
+    assert attribution.harness_id == "codex"
+
+
+def test_env_stamp_is_the_fallback() -> None:
+    attribution = resolve_attribution(
+        environ={"SKILLROUTE_HARNESS": "hermes", "SKILLROUTE_HARNESS_VERSION": "2.1.0"},
+        surface="acp",
+    )
+    assert attribution.harness_id == "hermes"
+    assert attribution.harness_version == "2.1.0"
+    assert attribution.surface == "acp"
+
+
+def test_unknown_caller_is_normal_not_an_error() -> None:
+    attribution = resolve_attribution(environ={})
+    assert attribution.harness_id is None
+    assert attribution.surface == "cli"
+
+
+def test_blank_values_are_treated_as_absent() -> None:
+    attribution = resolve_attribution(explicit="   ", environ={"SKILLROUTE_HARNESS": ""})
+    assert attribution.harness_id is None
+
+
+def test_unrecognized_surface_falls_back_to_cli() -> None:
+    assert resolve_attribution(surface="telepathy", environ={}).surface == "cli"
+
+
+def test_route_records_attribution_on_the_trace(
+    indexed_catalog: Catalog, tmp_path: Path
+) -> None:
+    router = Router(indexed_catalog)
+    router.route(
+        "Build an MCP server with stdio transport",
+        limit=3,
+        attribution=Attribution(harness_id="pi", harness_version="0.9.2", surface="mcp"),
+    )
+
+    with indexed_catalog._session() as connection:
+        row = connection.execute(
+            "SELECT harness_id, harness_version, surface, weights_json FROM route_traces"
+        ).fetchone()
+    assert row["harness_id"] == "pi"
+    assert row["harness_version"] == "0.9.2"
+    assert row["surface"] == "mcp"
+    # Weights are recorded so an eval trend can attribute movement to a config.
+    assert '"lexical"' in row["weights_json"]
+
+
+def test_route_without_attribution_records_unknown_harness(
+    indexed_catalog: Catalog,
+) -> None:
+    Router(indexed_catalog).route("Build an MCP server", limit=2)
+
+    with indexed_catalog._session() as connection:
+        row = connection.execute(
+            "SELECT harness_id, surface FROM route_traces"
+        ).fetchone()
+    assert row["harness_id"] is None
+    assert row["surface"] == "cli"
+
+
+def test_cli_route_honors_the_harness_env_stamp(
+    indexed_catalog: Catalog, monkeypatch, capsys
+) -> None:
+    """Regression: SKILLROUTE_HARNESS was set by generated configs but ignored.
+
+    The env stamp is the fallback attribution path for ACP and direct CLI use,
+    where there is no MCP handshake to read a client name from.
+    """
+    monkeypatch.setenv("SKILLROUTE_HARNESS", "pi")
+    main(["--catalog", str(indexed_catalog.path), "route", "Build an MCP server"])
+    capsys.readouterr()
+
+    with indexed_catalog._session() as connection:
+        row = connection.execute("SELECT harness_id FROM route_traces").fetchone()
+    assert row["harness_id"] == "pi"
+
+
+def test_cli_harness_flag_overrides_the_env_stamp(
+    indexed_catalog: Catalog, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("SKILLROUTE_HARNESS", "pi")
+    main(
+        [
+            "--catalog",
+            str(indexed_catalog.path),
+            "route",
+            "Build an MCP server",
+            "--harness",
+            "hermes",
+        ]
+    )
+    capsys.readouterr()
+
+    with indexed_catalog._session() as connection:
+        row = connection.execute("SELECT harness_id FROM route_traces").fetchone()
+    assert row["harness_id"] == "hermes"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from skillroute.catalog import Catalog
+from skillroute.catalog import (
+    DEFAULT_MAX_ROUTE_TRACES as SCHEMA_DEFAULT_TRACES,
+)
+from skillroute.catalog import (
+    SCHEMA_VERSION,
+    Catalog,
+    max_route_traces,
+)
 from skillroute.routing import Router
 
 
@@ -96,11 +103,14 @@ def test_all_backend_refs_returns_one_query_keyed_by_skill(indexed_catalog: Cata
 
 
 def test_schema_version_is_readable(indexed_catalog: Catalog) -> None:
-    assert indexed_catalog.schema_version() == 1
+    assert indexed_catalog.schema_version() == SCHEMA_VERSION
 
 
 def test_route_traces_are_pruned_to_max(tmp_path: Path, monkeypatch) -> None:
+    # PRUNE_INTERVAL amortizes the OFFSET subquery; force it every insert so the
+    # cap can be asserted exactly.
     monkeypatch.setattr("skillroute.catalog.MAX_ROUTE_TRACES", 3)
+    monkeypatch.setattr("skillroute.catalog.PRUNE_INTERVAL", 1)
     catalog = Catalog(tmp_path / "catalog.db")
     router = Router(catalog)
     for index in range(6):
@@ -108,6 +118,92 @@ def test_route_traces_are_pruned_to_max(tmp_path: Path, monkeypatch) -> None:
 
     traces = catalog.list_route_traces(limit=100)
     assert len(traces) == 3
+
+
+def test_route_trace_pruning_is_amortized(tmp_path: Path, monkeypatch) -> None:
+    """Between prunes the table may exceed the cap -- bounded by the interval."""
+    monkeypatch.setattr("skillroute.catalog.MAX_ROUTE_TRACES", 2)
+    monkeypatch.setattr("skillroute.catalog.PRUNE_INTERVAL", 4)
+    catalog = Catalog(tmp_path / "catalog.db")
+    router = Router(catalog)
+    for index in range(6):
+        router.route(f"Build an MCP server variant {index}", limit=1)
+
+    # Pruned at insert 4 (down to 2), then 5 and 6 accumulated on top.
+    assert len(catalog.list_route_traces(limit=100)) == 4
+
+
+def test_max_route_traces_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("SKILLROUTE_MAX_TRACES", "77")
+    assert max_route_traces() == 77
+    # 0 means "never prune", not "keep nothing".
+    monkeypatch.setenv("SKILLROUTE_MAX_TRACES", "0")
+    assert max_route_traces() == 0
+    monkeypatch.setenv("SKILLROUTE_MAX_TRACES", "not-a-number")
+    assert max_route_traces() == SCHEMA_DEFAULT_TRACES
+
+
+def test_daily_rollup_survives_trace_pruning(tmp_path: Path, monkeypatch) -> None:
+    """The point of the rollup: aggregates outlive the raw rows."""
+    monkeypatch.setattr("skillroute.catalog.MAX_ROUTE_TRACES", 2)
+    monkeypatch.setattr("skillroute.catalog.PRUNE_INTERVAL", 1)
+    catalog = Catalog(tmp_path / "catalog.db")
+    router = Router(catalog)
+    for index in range(5):
+        router.route(f"Build an MCP server variant {index}", limit=1)
+
+    assert len(catalog.list_route_traces(limit=100)) == 2
+    with catalog._session() as connection:
+        row = connection.execute(
+            "SELECT SUM(route_count) AS routes FROM route_trace_daily"
+        ).fetchone()
+    assert row["routes"] == 5
+
+
+def test_daily_rollup_histogram_counts_each_route_once(indexed_catalog: Catalog) -> None:
+    """Regression: the first route of a day was counted twice.
+
+    The INSERT seeded the bucket at 1 and the Python read-modify-write then
+    incremented it again, so a single route reported two.
+    """
+    router = Router(indexed_catalog)
+    router.route("Build an MCP server with stdio transport", limit=1)
+
+    with indexed_catalog._session() as connection:
+        row = connection.execute(
+            "SELECT route_count, histogram_json FROM route_trace_daily"
+        ).fetchone()
+    assert row["route_count"] == 1
+    assert sum(json.loads(row["histogram_json"]).values()) == 1
+
+    router.route("Test a Python application with pytest", limit=1)
+    with indexed_catalog._session() as connection:
+        row = connection.execute(
+            "SELECT route_count, histogram_json FROM route_trace_daily"
+        ).fetchone()
+    assert row["route_count"] == 2
+    assert sum(json.loads(row["histogram_json"]).values()) == 2
+
+
+def test_record_outcome_resolves_rank_and_rejects_unknown_uid(
+    indexed_catalog: Catalog,
+) -> None:
+    catalog = indexed_catalog
+    router = Router(catalog)
+    response = router.route("Build an MCP server with stdio transport", limit=3)
+    with catalog._session() as connection:
+        trace_uid = connection.execute(
+            "SELECT trace_uid FROM route_traces ORDER BY id DESC LIMIT 1"
+        ).fetchone()["trace_uid"]
+
+    second = response.candidates[1]
+    result = catalog.record_outcome(trace_uid, skill_id=second.skill_id, helpful=True)
+    assert result["recorded"] is True
+    # Rank comes from the recorded candidates, not from the caller.
+    assert result["rank_used"] == 2
+
+    missing = catalog.record_outcome("does-not-exist", skill_id="whatever")
+    assert missing["recorded"] is False
 
 
 def test_index_root_skips_malformed_skill(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -892,3 +892,36 @@ def test_cli_route_reports_bad_weights_env_cleanly(
     with pytest.raises(SystemExit) as excinfo:
         main(["--catalog", str(catalog_path), "search", "mcp"])
     assert "must be >= 0" in str(excinfo.value)
+
+
+def test_harness_doctor_reports_every_pack(capsys: pytest.CaptureFixture[str]) -> None:
+    main(["harness", "doctor", "--no-probe"])
+    out = capsys.readouterr().out
+    assert "harness(es) checked" in out
+
+
+def test_harness_doctor_json_is_machine_readable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    main(["harness", "doctor", "claude-code", "--no-probe", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["harness"] == "claude-code"
+    assert {"name", "status", "detail"} <= set(payload[0]["checks"][0])
+
+
+def test_harness_doctor_rejects_an_unknown_harness() -> None:
+    with pytest.raises(SystemExit, match="Unsupported harness"):
+        main(["harness", "doctor", "nope", "--no-probe"])
+
+
+def test_harness_doctor_exits_nonzero_when_a_probe_fails(tmp_path: Path) -> None:
+    """A repo root with no built server is the drift case doctor exists for."""
+    from skillroute.harness_doctor import STATUS_FAIL, run_doctor
+
+    reports = run_doctor(
+        ["claude-code"], repo_root=tmp_path, catalog=tmp_path / "c.db", probe=True
+    )
+    statuses = {check.name: check.status for check in reports[0].checks}
+    # Either the harness is absent here (probe skipped) or the probe ran and
+    # failed against a nonexistent entrypoint; both are correct, neither is ok.
+    assert statuses["server"] in {STATUS_FAIL, "skip"}

--- a/tests/test_client_setup.py
+++ b/tests/test_client_setup.py
@@ -19,6 +19,7 @@ from skillroute.client_setup import (
     run_setup_command,
     select_clients,
 )
+from skillroute.harnesses import harness_ids
 
 
 def test_detect_clients_uses_commands_and_paths(tmp_path: Path) -> None:
@@ -36,6 +37,9 @@ def test_detect_clients_uses_commands_and_paths(tmp_path: Path) -> None:
             "cursor": "/usr/local/bin/cursor",
         },
         existing_paths={bob_config, Path("/Applications/Claude.app"), windsurf_config},
+        # Detection is per-platform now, and /Applications/*.app only counts on
+        # macOS. v0.1 checked those paths on every platform.
+        platform="macos",
     )
 
     detections = {detection.id: detection for detection in detect_clients(env)}
@@ -59,7 +63,7 @@ def test_select_clients_auto_all_and_requested(tmp_path: Path) -> None:
 
     assert [detection.id for detection in select_clients("auto", detections)] == ["codex"]
     assert [detection.id for detection in select_clients("codex,cursor", detections)] == ["codex", "cursor"]
-    assert len(select_clients("all", detections)) == 7
+    assert len(select_clients("all", detections)) == len(harness_ids())
     with pytest.raises(SystemExit):
         select_clients("not-a-client", detections)
 
@@ -120,7 +124,7 @@ def test_apply_vscode_setup_uses_detected_command(
         calls.append((command_parts, check))
         return subprocess.CompletedProcess(command_parts, 0)
 
-    monkeypatch.setattr("skillroute.client_setup.subprocess.run", fake_run)
+    monkeypatch.setattr("skillroute.harness_setup.subprocess.run", fake_run)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     detection = ClientDetection(
@@ -152,7 +156,7 @@ def test_apply_missing_command_client_skips_without_running(
     def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
         raise AssertionError("subprocess.run should not be called for a missing command client")
 
-    monkeypatch.setattr("skillroute.client_setup.subprocess.run", fake_run)
+    monkeypatch.setattr("skillroute.harness_setup.subprocess.run", fake_run)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     detection = ClientDetection(
@@ -189,13 +193,13 @@ def test_setup_command_skips_prompt_mode_without_tty(
         command="/bin/codex",
     )
 
-    monkeypatch.setattr("skillroute.client_setup.detect_clients", lambda _env: [detection])
-    monkeypatch.setattr("skillroute.client_setup.can_prompt", lambda: False)
+    monkeypatch.setattr("skillroute.harness_setup.detect_harnesses", lambda _env: [detection])
+    monkeypatch.setattr("skillroute.harness_setup.can_prompt", lambda: False)
 
     def fail_setup(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("client setup should not run without a promptable terminal")
 
-    monkeypatch.setattr("skillroute.client_setup.apply_client_setup", fail_setup)
+    monkeypatch.setattr("skillroute.harness_setup.apply_harness_setup", fail_setup)
 
     run_setup_command(
         Namespace(
@@ -274,7 +278,10 @@ def test_run_detect_command_json_lists_all_clients(capsys: pytest.CaptureFixture
     run_detect_command(Namespace(as_json=True))
 
     payload = json.loads(capsys.readouterr().out)
-    assert {entry["id"] for entry in payload} == {
+    # Every harness with a manifest is listed, and the seven v0.1 clients are
+    # still among them.
+    assert {entry["id"] for entry in payload} == set(harness_ids())
+    assert {
         "ibm-bob",
         "codex",
         "claude-code",
@@ -282,7 +289,7 @@ def test_run_detect_command_json_lists_all_clients(capsys: pytest.CaptureFixture
         "vscode",
         "windsurf",
         "cursor",
-    }
+    } <= {entry["id"] for entry in payload}
 
 
 def test_client_setup_module_main_detect_json(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_harness_doctor.py
+++ b/tests/test_harness_doctor.py
@@ -1,0 +1,290 @@
+"""Tests for ``skillroute harness doctor``.
+
+The conformance tests here are parametrized over whatever is in ``harnesses/``,
+matching ``test_harnesses.py``: a new manifest is checked automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from skillroute.harness_doctor import (
+    STATUS_FAIL,
+    STATUS_OK,
+    STATUS_SKIP,
+    STATUS_WARN,
+    DoctorCheck,
+    DoctorReport,
+    check_config,
+    check_platform,
+    check_render,
+    probe_server,
+    run_doctor,
+    worst_status,
+)
+from skillroute.harness_setup import HarnessEnvironment
+from skillroute.harnesses import current_platform, load_manifests
+
+MANIFESTS = sorted(load_manifests())
+
+
+def fake_server(tmp_path: Path, body: str) -> list[str]:
+    """A stdio server stand-in, so the probe is exercised for real."""
+    script = tmp_path / "fake_server.py"
+    script.write_text(textwrap.dedent(body), encoding="utf-8")
+    return [sys.executable, str(script)]
+
+
+ANSWERS = """
+    import json, sys
+    sys.stdin.readline()
+    sys.stdout.write(json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"serverInfo": {"name": "skillroute", "version": "0.2.0"}},
+    }) + "\\n")
+    sys.stdout.flush()
+"""
+
+CRASHES = """
+    import sys
+    sys.stderr.write("boom\\n")
+    sys.exit(3)
+"""
+
+HANGS = """
+    import time
+    time.sleep(30)
+"""
+
+GARBAGE = """
+    import sys
+    sys.stdout.write("not json at all\\n")
+    sys.stdout.flush()
+"""
+
+ERROR_REPLY = """
+    import json, sys
+    sys.stdin.readline()
+    sys.stdout.write(json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32601, "message": "method not found"},
+    }) + "\\n")
+    sys.stdout.flush()
+"""
+
+
+# --- worst_status ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("statuses", "expected"),
+    [
+        ((), STATUS_OK),
+        ((STATUS_OK, STATUS_OK), STATUS_OK),
+        ((STATUS_OK, STATUS_SKIP), STATUS_OK),
+        ((STATUS_OK, STATUS_WARN), STATUS_WARN),
+        ((STATUS_WARN, STATUS_FAIL), STATUS_FAIL),
+        ((STATUS_FAIL, STATUS_OK), STATUS_FAIL),
+    ],
+)
+def test_worst_status(statuses: tuple[str, ...], expected: str) -> None:
+    assert worst_status(statuses) == expected
+
+
+# --- probe ----------------------------------------------------------------
+
+
+def test_probe_accepts_a_server_that_answers_initialize(tmp_path: Path) -> None:
+    check = probe_server(fake_server(tmp_path, ANSWERS), env={}, timeout=10.0)
+    assert check.status == STATUS_OK
+    assert "skillroute" in check.detail
+
+
+def test_probe_fails_when_the_server_exits_nonzero(tmp_path: Path) -> None:
+    check = probe_server(fake_server(tmp_path, CRASHES), env={}, timeout=10.0)
+    assert check.status == STATUS_FAIL
+    assert "exit" in check.detail.lower()
+
+
+def test_probe_fails_when_the_server_hangs(tmp_path: Path) -> None:
+    check = probe_server(fake_server(tmp_path, HANGS), env={}, timeout=0.5)
+    assert check.status == STATUS_FAIL
+    assert "did not answer" in check.detail
+
+
+def test_probe_fails_on_non_json_output(tmp_path: Path) -> None:
+    check = probe_server(fake_server(tmp_path, GARBAGE), env={}, timeout=10.0)
+    assert check.status == STATUS_FAIL
+
+
+def test_probe_fails_on_a_jsonrpc_error_reply(tmp_path: Path) -> None:
+    check = probe_server(fake_server(tmp_path, ERROR_REPLY), env={}, timeout=10.0)
+    assert check.status == STATUS_FAIL
+    assert "method not found" in check.detail
+
+
+def test_probe_fails_when_the_command_is_missing(tmp_path: Path) -> None:
+    check = probe_server(["definitely-not-a-real-binary-xyz"], env={}, timeout=5.0)
+    assert check.status == STATUS_FAIL
+
+
+# --- platform coverage ----------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", MANIFESTS)
+def test_every_manifest_has_a_path_on_this_platform(harness: str) -> None:
+    """The macOS-only detection bug in v0.1, as a standing check."""
+    manifest = load_manifests()[harness]
+    check = check_platform(manifest, current_platform())
+    assert check.status != STATUS_FAIL, check.detail
+
+
+def test_platform_check_fails_when_no_path_is_declared() -> None:
+    from skillroute.harnesses import parse_manifest
+
+    manifest = parse_manifest(
+        {
+            "schema": 1,
+            "id": "ghost",
+            "display_name": "Ghost",
+            "modes": {
+                "mcp": {
+                    "setup_method": "json_merge",
+                    "emitter": "mcp_servers",
+                    "write_path": {"macos": "~/.ghost/mcp.json"},
+                }
+            },
+        }
+    )
+    assert check_platform(manifest, "macos").status == STATUS_OK
+    assert check_platform(manifest, "linux").status == STATUS_FAIL
+
+
+# --- render ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", MANIFESTS)
+def test_every_mode_of_every_manifest_renders(harness: str, tmp_path: Path) -> None:
+    """Placeholder drift is a fail, not a traceback at a user's terminal."""
+    for check in check_render(harness, repo_root=tmp_path, catalog=tmp_path / "c.db"):
+        assert check.status != STATUS_FAIL, f"{harness}: {check.detail}"
+
+
+# --- config ---------------------------------------------------------------
+
+
+def test_config_check_warns_when_the_file_is_absent(tmp_path: Path) -> None:
+    check = check_config(tmp_path / "nope.json", server_name="skillroute", config_format="json")
+    assert check.status == STATUS_WARN
+    assert "not configured" in check.detail
+
+
+def test_config_check_passes_when_the_server_entry_is_present(tmp_path: Path) -> None:
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"mcpServers": {"skillroute": {"command": "node"}}}), "utf-8")
+    assert check_config(path, server_name="skillroute", config_format="json").status == STATUS_OK
+
+
+def test_config_check_warns_when_another_server_is_configured(tmp_path: Path) -> None:
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"mcpServers": {"other": {"command": "node"}}}), "utf-8")
+    check = check_config(path, server_name="skillroute", config_format="json")
+    assert check.status == STATUS_WARN
+
+
+def test_config_check_fails_on_malformed_json(tmp_path: Path) -> None:
+    path = tmp_path / "mcp.json"
+    path.write_text("{not json", encoding="utf-8")
+    check = check_config(path, server_name="skillroute", config_format="json")
+    assert check.status == STATUS_FAIL
+    assert "parse" in check.detail.lower()
+
+
+def test_config_check_skips_non_json_formats(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("mcp_servers: {}", encoding="utf-8")
+    check = check_config(path, server_name="skillroute", config_format="yaml")
+    assert check.status == STATUS_SKIP
+
+
+# --- end to end -----------------------------------------------------------
+
+
+def test_run_doctor_reports_every_requested_harness(tmp_path: Path) -> None:
+    reports = run_doctor(
+        ["claude-code", "codex"],
+        env=HarnessEnvironment(home=tmp_path, commands={}, existing_paths=set()),
+        repo_root=tmp_path,
+        catalog=tmp_path / "catalog.db",
+        probe=False,
+    )
+    assert [report.harness for report in reports] == ["claude-code", "codex"]
+    for report in reports:
+        assert report.checks
+        assert report.status in {STATUS_OK, STATUS_WARN, STATUS_FAIL}
+
+
+def test_run_doctor_marks_an_absent_harness_as_a_warning_not_a_failure(
+    tmp_path: Path,
+) -> None:
+    (report,) = run_doctor(
+        ["claude-code"],
+        env=HarnessEnvironment(home=tmp_path, commands={}, existing_paths=set()),
+        repo_root=tmp_path,
+        catalog=tmp_path / "catalog.db",
+        probe=False,
+    )
+    assert report.status == STATUS_WARN
+    detect = next(check for check in report.checks if check.name == "detect")
+    assert detect.status == STATUS_WARN
+
+
+def test_run_doctor_skips_the_probe_when_asked(tmp_path: Path) -> None:
+    (report,) = run_doctor(
+        ["claude-code"],
+        env=HarnessEnvironment(home=tmp_path, commands={}, existing_paths=set()),
+        repo_root=tmp_path,
+        catalog=tmp_path / "catalog.db",
+        probe=False,
+    )
+    probe = next((check for check in report.checks if check.name == "server"), None)
+    assert probe is None or probe.status == STATUS_SKIP
+
+
+def test_run_doctor_rejects_an_unknown_harness(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="nope"):
+        run_doctor(["nope"], repo_root=tmp_path, probe=False)
+
+
+def test_doctor_report_is_json_serializable(tmp_path: Path) -> None:
+    reports = run_doctor(
+        ["claude-code"],
+        env=HarnessEnvironment(home=tmp_path, commands={}, existing_paths=set()),
+        repo_root=tmp_path,
+        catalog=tmp_path / "catalog.db",
+        probe=False,
+    )
+    payload = json.dumps([report.to_dict() for report in reports])
+    restored = json.loads(payload)
+    assert restored[0]["harness"] == "claude-code"
+    assert isinstance(restored[0]["checks"], list)
+
+
+def test_report_status_is_the_worst_check() -> None:
+    report = DoctorReport(
+        harness="x",
+        name="X",
+        checks=(
+            DoctorCheck("a", STATUS_OK, ""),
+            DoctorCheck("b", STATUS_FAIL, ""),
+            DoctorCheck("c", STATUS_WARN, ""),
+        ),
+    )
+    assert report.status == STATUS_FAIL

--- a/tests/test_harnesses.py
+++ b/tests/test_harnesses.py
@@ -1,0 +1,406 @@
+"""Conformance tests over every harness manifest.
+
+These are parametrized across whatever is in ``harnesses/``, so adding a harness
+adds its coverage automatically: drop in a ``.toml`` and these tests start
+checking it. That is the property that makes a new harness cheap to contribute.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skillroute.harness_render import (
+    EMITTERS,
+    PLACEHOLDER,
+    RenderError,
+    build_harness_setup,
+    render_harness_setup,
+)
+from skillroute.harness_setup import HarnessEnvironment, detect_harness
+from skillroute.harnesses import (
+    INSTALL_MODES,
+    PLATFORMS,
+    SETUP_METHODS,
+    ManifestError,
+    current_platform,
+    harness_for_client_name,
+    load_manifests,
+    manifest_for,
+    parse_manifest,
+    skill_discovery_globs,
+)
+
+MANIFESTS = load_manifests()
+HARNESS_IDS = sorted(MANIFESTS)
+# Every (harness, mode) pair in the repo, as test ids like "pi/skills".
+MODE_PAIRS = [
+    pytest.param(harness, mode, id=f"{harness}/{mode}")
+    for harness in HARNESS_IDS
+    for mode in sorted(MANIFESTS[harness].modes)
+]
+REPO_ROOT = Path("/repo")
+CATALOG = Path("/repo/.skillroute/catalog.db")
+
+# The clients v0.1 shipped. They must keep working through the deprecated shim.
+LEGACY_CLIENTS = {
+    "ibm-bob",
+    "codex",
+    "claude-code",
+    "claude-desktop",
+    "vscode",
+    "windsurf",
+    "cursor",
+}
+
+
+def test_manifests_are_present() -> None:
+    assert MANIFESTS, "no harness manifests found -- is harnesses/ packaged?"
+    assert LEGACY_CLIENTS <= set(MANIFESTS)
+
+
+@pytest.mark.parametrize("harness", HARNESS_IDS)
+def test_manifest_is_well_formed(harness: str) -> None:
+    manifest = MANIFESTS[harness]
+    assert manifest.id == harness
+    assert manifest.display_name.strip()
+    assert manifest.modes, f"{harness} declares no install modes"
+    assert set(manifest.modes) <= set(INSTALL_MODES)
+    # Every harness must at least be reachable over MCP.
+    assert manifest.supports("mcp"), f"{harness} does not support mcp"
+
+
+@pytest.mark.parametrize("harness", HARNESS_IDS)
+def test_declared_emitters_and_methods_exist(harness: str) -> None:
+    for mode in MANIFESTS[harness].modes.values():
+        assert mode.setup_method in SETUP_METHODS
+        if mode.emitter:
+            assert mode.emitter in EMITTERS, (
+                f"{harness}/{mode.mode} names unknown emitter {mode.emitter!r}"
+            )
+
+
+@pytest.mark.parametrize(("harness", "mode"), MODE_PAIRS)
+def test_every_mode_renders_on_every_platform(harness: str, mode: str) -> None:
+    """No manifest may reference a placeholder the renderer cannot supply."""
+    for platform in PLATFORMS:
+        payload = build_harness_setup(
+            harness=harness,
+            mode=mode,
+            repo_root=REPO_ROOT,
+            catalog=CATALOG,
+            backend="local",
+            platform=platform,
+        )
+        assert payload["harness"] == harness
+        assert payload["mode"] == mode
+        assert payload["setup_method"] in SETUP_METHODS
+        # A command install is useless without argv to run.
+        if payload["setup_method"] == "command":
+            assert payload["install_command_parts"]
+            assert payload["install_command"]
+
+
+@pytest.mark.parametrize(("harness", "mode"), MODE_PAIRS)
+def test_every_mode_renders_human_output(harness: str, mode: str) -> None:
+    payload = build_harness_setup(
+        harness=harness, mode=mode, repo_root=REPO_ROOT, catalog=CATALOG
+    )
+    text = render_harness_setup(payload)
+    assert MANIFESTS[harness].display_name in text
+    # A leftover {placeholder} means the manifest named something the renderer
+    # never filled in. Braces themselves are fine -- VS Code's install command
+    # legitimately embeds a JSON object.
+    assert not PLACEHOLDER.search(text), (
+        f"unsubstituted placeholder in rendered output: {PLACEHOLDER.search(text)}"
+    )
+
+
+@pytest.mark.parametrize("harness", HARNESS_IDS)
+def test_no_manifest_merges_a_format_we_cannot_write(harness: str) -> None:
+    """SkillRoute never rewrites a user's TOML or YAML.
+
+    ``tomllib`` cannot write, we carry no YAML dependency, and hand-merging
+    someone's config file is not worth the blast radius. Those formats must
+    install via a command or be printed for the user to paste.
+    """
+    for mode in MANIFESTS[harness].modes.values():
+        if mode.config_format in {"toml", "yaml"}:
+            assert mode.setup_method != "json_merge", (
+                f"{harness}/{mode.mode} would merge {mode.config_format}"
+            )
+
+
+@pytest.mark.parametrize("harness", HARNESS_IDS)
+def test_detection_finds_a_harness_from_its_own_manifest(
+    harness: str, tmp_path: Path
+) -> None:
+    """Synthesize an environment from what the manifest declares, and find it."""
+    manifest = MANIFESTS[harness]
+    home = tmp_path / "home"
+    for platform in PLATFORMS:
+        paths = manifest.detect.paths_for(platform) + manifest.detect.apps_for(platform)
+        commands = manifest.detect.commands
+        if not paths and not commands:
+            continue
+        env = HarnessEnvironment(home=home, commands={}, existing_paths=set(), platform=platform)
+        populated = HarnessEnvironment(
+            home=home,
+            commands={command: f"/usr/bin/{command}" for command in commands},
+            existing_paths={env.resolve(raw) for raw in paths},
+            platform=platform,
+        )
+        assert detect_harness(manifest, populated).detected is True
+        assert detect_harness(manifest, env).detected is False
+
+
+@pytest.mark.parametrize("harness", HARNESS_IDS)
+def test_client_names_map_back_to_their_harness(harness: str) -> None:
+    for client_name in MANIFESTS[harness].detect.client_names:
+        if "*" in client_name:
+            continue
+        assert harness_for_client_name(client_name) is not None
+
+
+def test_client_name_matching_is_case_insensitive_and_globbed() -> None:
+    assert harness_for_client_name("Claude-Code") == "claude-code"
+    assert harness_for_client_name("claude-code-web") == "claude-code"
+    assert harness_for_client_name("") is None
+    assert harness_for_client_name("no-such-editor") is None
+
+
+def test_skill_discovery_covers_the_harnesses_that_have_skills() -> None:
+    globs = skill_discovery_globs()
+    # The v0.1 hardcoded list missed Claude Code entirely.
+    assert any(".claude/skills" in glob for glob in globs)
+    assert any(".codex/skills" in glob for glob in globs)
+    assert any("pi/agent/skills" in glob for glob in globs)
+
+
+def test_unknown_harness_is_rejected_with_the_valid_list() -> None:
+    with pytest.raises(ValueError, match="Unsupported harness"):
+        manifest_for("not-a-harness")
+
+
+def test_unsupported_mode_is_rejected() -> None:
+    with pytest.raises(ValueError, match="does not support mode"):
+        build_harness_setup(harness="amp", mode="extension")
+
+
+def test_unsupported_scope_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported scope"):
+        build_harness_setup(harness="claude-code", mode="mcp", scope="galaxy")
+
+
+# --- manifest validation -------------------------------------------------
+
+
+def minimal_manifest(**overrides: object) -> dict:
+    base = {
+        "schema": 1,
+        "id": "demo",
+        "display_name": "Demo",
+        "modes": {"mcp": {"setup_method": "json_merge", "emitter": "mcp_servers"}},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_manifest_accepts_a_minimal_manifest() -> None:
+    manifest = parse_manifest(minimal_manifest())
+    assert manifest.id == "demo"
+    assert manifest.tier == "breadth"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"schema": 99}, "schema must be"),
+        ({"id": ""}, "missing required string field"),
+        ({"tier": "gold"}, "tier"),
+        ({"modes": {"telepathy": {"setup_method": "json_merge"}}}, "unknown install mode"),
+        ({"modes": {"mcp": {"setup_method": "carrier_pigeon"}}}, "setup_method"),
+        ({"modes": {"mcp": {"setup_method": "command"}}}, "requires argv"),
+        ({"detect": {"paths": {"solaris": ["~/x"]}}}, "must be 'all' or one of"),
+        ({"detect": {"commands": "claude"}}, "must be a list of strings"),
+        (
+            {
+                "modes": {
+                    "mcp": {
+                        "setup_method": "json_merge",
+                        "scopes": ["user"],
+                        "default_scope": "project",
+                    }
+                }
+            },
+            "default_scope",
+        ),
+    ],
+)
+def test_parse_manifest_rejects_malformed_input(overrides: dict, match: str) -> None:
+    with pytest.raises(ManifestError, match=match):
+        parse_manifest(minimal_manifest(**overrides))
+
+
+def test_render_rejects_an_unknown_placeholder() -> None:
+    from skillroute.harness_render import _substitute
+
+    with pytest.raises(RenderError, match="Unknown placeholder"):
+        _substitute("{nonsense}", {"catalog": "/x"})
+
+
+def test_splat_placeholder_cannot_be_used_inside_a_string() -> None:
+    from skillroute.harness_render import _substitute
+
+    with pytest.raises(RenderError, match="expands to multiple values"):
+        _substitute("prefix-{server_argv}", {"server_argv": ["node", "index.js"]})
+
+
+# --- emitter shapes ------------------------------------------------------
+#
+# One assertion per emitter, pinning the shape that harness actually expects.
+
+
+def setup(harness: str, mode: str = "mcp", **kwargs: object) -> dict:
+    return build_harness_setup(
+        harness=harness, mode=mode, repo_root=REPO_ROOT, catalog=CATALOG, backend="local", **kwargs
+    )
+
+
+def test_mcp_servers_shape() -> None:
+    config = setup("claude-code")["config"]
+    assert list(config) == ["mcpServers"]
+    assert config["mcpServers"]["skillroute"]["command"] == "node"
+
+
+def test_vscode_uses_servers_key_and_embeds_the_name() -> None:
+    payload = setup("vscode")
+    assert list(payload["config"]) == ["servers"]
+    # VS Code's --add-mcp payload carries the name inside the object.
+    assert payload["server_config"]["name"] == "skillroute"
+    assert payload["install_command_parts"][1] == "--add-mcp"
+
+
+def test_ibm_bob_adds_cwd_and_disabled() -> None:
+    server = setup("ibm-bob")["config"]["mcpServers"]["skillroute"]
+    assert server["cwd"] == str(REPO_ROOT)
+    assert server["disabled"] is False
+
+
+def test_codex_emits_toml_with_timeouts() -> None:
+    payload = setup("codex")
+    assert payload["config_format"] == "toml"
+    assert "[mcp_servers.skillroute]" in payload["config"]
+    assert "startup_timeout_sec = 20" in payload["config"]
+    assert "tool_timeout_sec = 60" in payload["config"]
+
+
+def test_opencode_nests_under_mcp_with_a_type() -> None:
+    server = setup("opencode")["config"]["mcp"]["skillroute"]
+    assert server["type"] == "local"
+    assert server["enabled"] is True
+    assert server["command"][0] == "node"
+
+
+def test_zed_uses_context_servers() -> None:
+    assert list(setup("zed")["config"]) == ["context_servers"]
+
+
+def test_amp_namespaces_its_settings_key() -> None:
+    assert list(setup("amp")["config"]) == ["amp.mcpServers"]
+
+
+def test_hermes_and_goose_emit_yaml_under_their_own_container() -> None:
+    hermes = setup("hermes")
+    assert hermes["config_format"] == "yaml"
+    assert hermes["config"].startswith("mcp_servers:")
+    assert hermes["setup_method"] == "print_only"
+
+    goose = setup("goose")
+    assert goose["config"].startswith("extensions:")
+
+
+def test_gemini_cli_reuses_the_standard_shape_with_no_new_emitter() -> None:
+    """Pure-data harness: proof the manifest system pays off."""
+    assert MANIFESTS["gemini-cli"].mode("mcp").emitter == "mcp_servers"
+    assert list(setup("gemini-cli")["config"]) == ["mcpServers"]
+
+
+def test_claude_code_scope_changes_the_config_path() -> None:
+    assert setup("claude-code", scope="user")["config_path"] == "~/.claude.json"
+    assert setup("claude-code", scope="project")["config_path"] == ".mcp.json"
+    assert "--scope" in setup("claude-code", scope="project")["install_command_parts"]
+
+
+def test_claude_hook_emits_a_session_start_entry() -> None:
+    config = setup("claude-code", mode="hook")["config"]
+    assert "SessionStart" in config["hooks"]
+
+
+def test_windows_paths_are_declared_where_they_differ() -> None:
+    """Cross-platform coverage is the point of per-platform manifest paths."""
+    goose = MANIFESTS["goose"].mode("mcp")
+    assert goose.path_for("windows") != goose.path_for("linux")
+    assert "APPDATA" in goose.path_for("windows")
+
+
+def test_current_platform_is_one_we_know() -> None:
+    assert current_platform() in PLATFORMS
+
+
+# --- CLI surface ---------------------------------------------------------
+
+
+def test_cli_harness_list_json_covers_every_manifest(capsys) -> None:
+    from skillroute.cli import main
+
+    main(["harness", "list", "--json"])
+    payload = __import__("json").loads(capsys.readouterr().out)
+    assert {entry["id"] for entry in payload} == set(HARNESS_IDS)
+    assert all(entry["modes"] for entry in payload)
+
+
+def test_cli_harness_list_filters_by_mode(capsys) -> None:
+    from skillroute.cli import main
+
+    main(["harness", "list", "--mode", "extension"])
+    out = capsys.readouterr().out
+    assert "pi" in out
+    assert "amp" not in out
+
+
+def test_cli_harness_show_renders_for_another_platform(capsys) -> None:
+    from skillroute.cli import main
+
+    main(["harness", "show", "goose", "--platform", "windows", "--json"])
+    payload = __import__("json").loads(capsys.readouterr().out)
+    assert "APPDATA" in payload["write_path"]
+
+
+def test_cli_harness_install_dry_run_changes_nothing(tmp_path: Path, capsys) -> None:
+    from skillroute.cli import main
+
+    main(
+        [
+            "harness",
+            "install",
+            "claude-code",
+            "--dry-run",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+    assert "SkillRoute MCP setup for Claude Code" in capsys.readouterr().out
+    assert not list(tmp_path.iterdir())
+
+
+def test_cli_mcp_config_deprecation_goes_to_stderr_only(capsys) -> None:
+    """`--json` stdout must stay machine-parseable."""
+    from skillroute.cli import main
+
+    main(["mcp", "config", "--client", "codex", "--json"])
+    captured = capsys.readouterr()
+    assert "deprecated" in captured.err
+    assert "deprecated" not in captured.out
+    assert __import__("json").loads(captured.out)["harness"] == "codex"

--- a/tests/test_harnesses.py
+++ b/tests/test_harnesses.py
@@ -404,3 +404,66 @@ def test_cli_mcp_config_deprecation_goes_to_stderr_only(capsys) -> None:
     assert "deprecated" in captured.err
     assert "deprecated" not in captured.out
     assert __import__("json").loads(captured.out)["harness"] == "codex"
+
+
+# --- server source (S2) ---------------------------------------------------
+
+
+def test_server_argv_local_points_at_the_checkout(tmp_path: Path) -> None:
+    from skillroute.harness_render import server_argv_for
+
+    argv = server_argv_for("local", repo_root=tmp_path)
+    assert argv[0] == "node"
+    assert argv[1].endswith("mcp/build/index.js")
+
+
+def test_server_argv_npx_points_at_the_published_package(tmp_path: Path) -> None:
+    from skillroute.harness_render import NPM_PACKAGE, server_argv_for
+
+    assert server_argv_for("npx", repo_root=tmp_path) == ["npx", "-y", NPM_PACKAGE]
+
+
+def test_server_argv_rejects_an_unknown_source(tmp_path: Path) -> None:
+    from skillroute.harness_render import RenderError, server_argv_for
+
+    with pytest.raises(RenderError, match="Unknown server source"):
+        server_argv_for("carrier-pigeon", repo_root=tmp_path)
+
+
+def test_default_server_source_stays_local_until_the_package_ships() -> None:
+    """Guards the S2 switch: flipping it must be deliberate, not incidental."""
+    from skillroute.harness_render import DEFAULT_SERVER_SOURCE
+
+    assert DEFAULT_SERVER_SOURCE == "local"
+
+
+@pytest.mark.parametrize("harness", sorted(load_manifests()))
+def test_every_harness_renders_against_both_server_sources(
+    harness: str, tmp_path: Path
+) -> None:
+    from skillroute.harness_render import SERVER_SOURCES, build_harness_setup
+
+    for source in SERVER_SOURCES:
+        payload = build_harness_setup(
+            harness=harness,
+            mode="mcp",
+            repo_root=tmp_path,
+            catalog=tmp_path / "c.db",
+            server_source=source,
+        )
+        assert payload["server_source"] == source
+
+
+def test_npx_source_drops_the_local_checkout_notes(tmp_path: Path) -> None:
+    from skillroute.harness_render import build_harness_setup
+
+    payload = build_harness_setup(
+        harness="claude-code",
+        mode="mcp",
+        repo_root=tmp_path,
+        catalog=tmp_path / "c.db",
+        server_source="npx",
+    )
+    joined = " ".join(payload["notes"])
+    assert "bootstrap.sh" not in joined
+    assert "npx" in joined

--- a/tests/test_harnesses.py
+++ b/tests/test_harnesses.py
@@ -7,6 +7,7 @@ checking it. That is the property that makes a new harness cheap to contribute.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -467,3 +468,66 @@ def test_npx_source_drops_the_local_checkout_notes(tmp_path: Path) -> None:
     joined = " ".join(payload["notes"])
     assert "bootstrap.sh" not in joined
     assert "npx" in joined
+
+
+def declares_key(config: object, key: str) -> bool:
+    """Is `key` a config *key*, not just a substring somewhere in a path?
+
+    Configs come back as dicts for JSON harnesses and as rendered text for the
+    TOML one, so both shapes need checking.
+    """
+    if isinstance(config, dict):
+        return key in config or any(declares_key(v, key) for v in config.values())
+    if isinstance(config, list):
+        return any(declares_key(item, key) for item in config)
+    if isinstance(config, str):
+        return any(
+            line.strip().startswith(f"{key} =") for line in config.splitlines()
+        )
+    return False
+
+
+@pytest.mark.parametrize("harness", ["codex", "ibm-bob"])
+def test_working_directory_is_dropped_for_a_published_server(
+    harness: str, tmp_path: Path
+) -> None:
+    """An npx-resolved package has no checkout, so cwd must not be emitted."""
+    from skillroute.harness_render import build_harness_setup
+
+    local = build_harness_setup(
+        harness=harness, mode="mcp", repo_root=tmp_path, catalog=tmp_path / "c.db"
+    )
+    npx = build_harness_setup(
+        harness=harness,
+        mode="mcp",
+        repo_root=tmp_path,
+        catalog=tmp_path / "c.db",
+        server_source="npx",
+    )
+    assert declares_key(local["config"], "cwd")
+    assert not declares_key(npx["config"], "cwd")
+
+
+def test_no_generated_config_leaks_a_checkout_path_under_npx(tmp_path: Path) -> None:
+    """The whole point of S2: an npx config must work off a clone."""
+    from skillroute.harness_render import build_harness_setup
+
+    marker = str(tmp_path)
+    for harness in sorted(load_manifests()):
+        payload = build_harness_setup(
+            harness=harness,
+            mode="mcp",
+            repo_root=tmp_path,
+            catalog=tmp_path / "c.db",
+            server_source="npx",
+        )
+        rendered = json.dumps(payload["config"]) + json.dumps(payload["server_config"])
+        # The catalog path is excluded deliberately, and it is the one thing
+        # still checkout-bound under npx: default_catalog_path() resolves to
+        # <repo_root>/.skillroute/catalog.db. Where a published install should
+        # keep its catalog is an open decision, so this asserts the rest of the
+        # config is clean rather than pretending that part is settled.
+        leaked = [
+            line for line in rendered.split('"') if marker in line and "c.db" not in line
+        ]
+        assert not leaked, f"{harness} leaked a checkout path: {leaked}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from skillroute.catalog import SCHEMA_VERSION, Catalog
+from skillroute.migrations import CatalogVersionError, detect_schema_version
+
+V1_SCHEMA = Path(__file__).parent / "fixtures" / "schema_v1.sql"
+
+
+def build_v1_catalog(path: Path, *, traces: list[tuple[dict, dict]] | None = None) -> None:
+    """Create a database in the exact shape v0.1.0 shipped."""
+    connection = sqlite3.connect(path)
+    try:
+        connection.executescript(V1_SCHEMA.read_text(encoding="utf-8"))
+        for request, response in traces or []:
+            connection.execute(
+                "INSERT INTO route_traces (request_json, response_json) VALUES (?, ?)",
+                (json.dumps(request, sort_keys=True), json.dumps(response, sort_keys=True)),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def sample_trace(request_text: str, *, clarification: bool = False) -> tuple[dict, dict]:
+    request = {"request": request_text, "repo": None, "limit": 5, "backend": "local-token"}
+    response = {
+        "request": request_text,
+        "repo_context": {},
+        "candidates": [
+            {
+                "skill_id": "mcp-server-patterns-abc123",
+                "name": "mcp-server-patterns",
+                "description": "Build MCP servers.",
+                "confidence": 0.42,
+                "content_hash": "hash-a",
+                "reasons": [],
+                "evidence": [],
+                "score_breakdown": {
+                    "lexical": 0.30,
+                    "semantic": 0.10,
+                    "repo_context": 0.05,
+                    "graph": 0.02,
+                    "total": 0.47,
+                },
+                "suggested_position": 1,
+            },
+            {
+                "skill_id": "python-testing-def456",
+                "name": "python-testing",
+                "description": "Test Python apps.",
+                "confidence": 0.13,
+                "content_hash": "hash-b",
+                "reasons": [],
+                "evidence": [],
+                "score_breakdown": {
+                    "lexical": 0.10,
+                    "semantic": 0.02,
+                    "repo_context": 0.0,
+                    "graph": 0.01,
+                    "total": 0.13,
+                },
+                "suggested_position": 2,
+            },
+        ],
+        "suggested_order": ["mcp-server-patterns-abc123", "python-testing-def456"],
+        "clarification_needed": clarification,
+        "clarification_questions": ["Which one?"] if clarification else [],
+    }
+    return request, response
+
+
+def table_names(connection: sqlite3.Connection) -> set[str]:
+    rows = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
+def column_names(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in connection.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def test_detects_fresh_v1_and_current_databases(tmp_path: Path) -> None:
+    empty = sqlite3.connect(tmp_path / "empty.db")
+    assert detect_schema_version(empty) == 0
+    empty.close()
+
+    build_v1_catalog(tmp_path / "v1.db")
+    v1 = sqlite3.connect(tmp_path / "v1.db")
+    assert detect_schema_version(v1) == 1
+    v1.close()
+
+
+def test_v1_catalog_without_version_table_reads_as_v1(tmp_path: Path) -> None:
+    """Tables but no version row means a catalog from before versioning landed."""
+    path = tmp_path / "unversioned.db"
+    build_v1_catalog(path)
+    connection = sqlite3.connect(path)
+    connection.execute("DROP TABLE schema_version")
+    connection.commit()
+    assert detect_schema_version(connection) == 1
+    connection.close()
+
+
+def test_migrates_v1_to_current_and_backfills_traces(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.db"
+    build_v1_catalog(
+        path,
+        traces=[
+            sample_trace("Build an MCP server"),
+            sample_trace("Ambiguous request", clarification=True),
+        ],
+    )
+
+    Catalog(path).initialize()
+
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        assert connection.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == (
+            SCHEMA_VERSION
+        )
+        traces = connection.execute(
+            "SELECT * FROM route_traces ORDER BY id"
+        ).fetchall()
+        assert len(traces) == 2
+
+        first = traces[0]
+        assert first["trace_uid"]
+        assert first["request_text"] == "Build an MCP server"
+        assert first["backend"] == "local-token"
+        assert first["top_skill_id"] == "mcp-server-patterns-abc123"
+        assert first["top_confidence"] == pytest.approx(0.42)
+        assert first["second_confidence"] == pytest.approx(0.13)
+        assert first["candidate_count"] == 2
+        assert first["clarification_needed"] == 0
+        # v1 never recorded a caller, so attribution is genuinely unknown.
+        assert first["harness_id"] is None
+        assert traces[1]["clarification_needed"] == 1
+
+        # Every trace got a distinct uid.
+        assert len({row["trace_uid"] for row in traces}) == 2
+
+        candidates = connection.execute(
+            """
+            SELECT * FROM route_trace_candidates
+            WHERE trace_id = ? ORDER BY position
+            """,
+            (first["id"],),
+        ).fetchall()
+        assert [row["position"] for row in candidates] == [1, 2]
+        assert candidates[0]["skill_id"] == "mcp-server-patterns-abc123"
+        assert candidates[0]["content_hash"] == "hash-a"
+        assert candidates[0]["lexical"] == pytest.approx(0.30)
+        assert candidates[1]["name"] == "python-testing"
+    finally:
+        connection.close()
+
+
+def test_migration_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.db"
+    build_v1_catalog(path, traces=[sample_trace("Build an MCP server")])
+
+    Catalog(path).initialize()
+    # A second Catalog object re-opens the file and must be a no-op.
+    Catalog(path).initialize()
+
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM schema_version").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM route_traces").fetchone()[0] == 1
+        assert (
+            connection.execute("SELECT COUNT(*) FROM route_trace_candidates").fetchone()[0] == 2
+        )
+    finally:
+        connection.close()
+
+
+def test_migration_writes_a_backup(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.db"
+    build_v1_catalog(path, traces=[sample_trace("Build an MCP server")])
+
+    Catalog(path).initialize()
+
+    backups = list(tmp_path.glob("catalog.db.bak-v1-*"))
+    assert len(backups) == 1
+    # The backup is still readable as the original v1 database.
+    connection = sqlite3.connect(backups[0])
+    try:
+        assert "route_trace_candidates" not in table_names(connection)
+    finally:
+        connection.close()
+
+
+def test_unreadable_trace_is_skipped_not_fatal(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "catalog.db"
+    build_v1_catalog(path, traces=[sample_trace("Good trace")])
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "INSERT INTO route_traces (request_json, response_json) VALUES (?, ?)",
+        ("{not json", "{also not json"),
+    )
+    connection.commit()
+    connection.close()
+
+    Catalog(path).initialize()
+
+    assert "skipped 1 unreadable route trace" in capsys.readouterr().err
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        rows = connection.execute(
+            "SELECT trace_uid FROM route_traces ORDER BY id"
+        ).fetchall()
+        # The good row migrated; the corrupt one survived without a uid.
+        assert rows[0]["trace_uid"]
+        assert rows[1]["trace_uid"] is None
+    finally:
+        connection.close()
+
+
+def test_refuses_a_newer_catalog(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.db"
+    build_v1_catalog(path)
+    connection = sqlite3.connect(path)
+    connection.execute("DELETE FROM schema_version")
+    connection.execute("INSERT INTO schema_version(version) VALUES (99)")
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(CatalogVersionError, match="schema v99"):
+        Catalog(path).initialize()
+
+
+def test_fresh_and_migrated_schemas_match(tmp_path: Path) -> None:
+    """The DDL exists twice -- as the current shape and as the steps to reach it.
+
+    This is the guard that keeps the two from drifting apart.
+    """
+    fresh_path = tmp_path / "fresh.db"
+    Catalog(fresh_path).initialize()
+
+    migrated_path = tmp_path / "migrated.db"
+    build_v1_catalog(migrated_path)
+    Catalog(migrated_path).initialize()
+
+    fresh = sqlite3.connect(fresh_path)
+    migrated = sqlite3.connect(migrated_path)
+    try:
+        assert table_names(fresh) == table_names(migrated)
+        for table in sorted(table_names(fresh)):
+            assert column_names(fresh, table) == column_names(migrated, table), table
+
+        def index_names(connection: sqlite3.Connection) -> set[str]:
+            rows = connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()
+            return {row[0] for row in rows}
+
+        assert index_names(fresh) == index_names(migrated)
+    finally:
+        fresh.close()
+        migrated.close()
+
+
+def test_user_version_pragma_mirrors_schema_version(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.db"
+    Catalog(path).initialize()
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    finally:
+        connection.close()

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "skillroute"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
The bulk of the 0.2 release: stages S0 and S1 complete, plus the groundwork S2 needs. The first two commits had been pushed to the branch without ever going through a pull request, so this is their first CI run.

| Commit | |
| --- | --- |
| `2330201` | S0 — catalog schema v2, migrations, attribution, outcomes |
| `439de7d` | S1 — declarative harness packs |
| `b7bc24f` | S1 — `harness doctor` |
| `7d47e34` | docs — changelog consolidation, roadmap rewrite |
| `511cb51` | S2 — `--server-source {local,npx}` |
| `d21b90d` | S2 — `cwd` no longer leaks into published configs |
| `6d1a94c` | S2 — npm trusted publishing, tag/version guard |
| `72bc64d` | S2 — bump to 0.2.0 |

443 tests (365 at the start of this branch), ruff and mypy clean.

**Merging this arms the release.** `PYPI_PUBLISH` and `NPM_PUBLISH` are set, the version is `0.2.0`, and the next `v*` tag attempts real publishes. Both registries still need their trusted publisher configured or those jobs will error (they upload nothing on failure, so this is safe to get wrong once).

## `2330201` — catalog schema v2, migrations, attribution, outcomes

0.2 turns route traces into a data layer, which needs a schema change on a file users keep across upgrades. There was no migration path at all: `initialize()` only ran `CREATE TABLE IF NOT EXISTS` and stamped a version when the table was empty.

- New `skillroute.migrations` with ordered, named migrations. `Catalog.initialize()` detects the on-disk version, takes `BEGIN IMMEDIATE` so a concurrent index and UI server cannot both migrate, copies the file aside before altering it, and raises `CatalogVersionError` on a catalog written by a newer build rather than corrupting it.
- The v1 → v2 migration unpacks existing trace JSON into the new columns instead of discarding history; an unreadable row is skipped with a warning rather than failing the upgrade.
- Schema v2 records who asked (`harness_id`, `harness_version`, `surface`) and what happened (`request_text`, top/second confidence, `weights_json`), denormalizes ranked candidates into `route_trace_candidates` so analytics can use SQL, adds `route_outcomes` for reported skill usage, and adds `route_trace_daily` so aggregates outlive trace pruning.
- Retention 1,000 → 20,000 (`SKILLROUTE_MAX_TRACES`, `0` disables). Pruning is amortized across inserts, so the table may sit slightly above the cap between prunes.

The DDL now exists twice — as the current shape for fresh catalogs, and as the steps to reach it. `test_migrations.py` guards that duplication by asserting a fresh database and a migrated one end up with identical tables, columns, and indexes.

Two bugs caught while verifying end-to-end: the daily histogram counted the first route of each day twice, and `SKILLROUTE_HARNESS` was written into generated configs but never read. Both fixed with regression tests.

## `439de7d` — declarative harness packs

Supporting an agent tool in 0.1 meant editing about seven places: the `MCP_CLIENT_CHOICES` tuple, a branch of the ~100-line if/elif in `build_mcp_setup()`, `CLIENT_ORDER`, a bespoke `detect_*` function, the `detect_clients()` list, and three docs/scripts that hardcoded the seven names. Detection was macOS-only, and only one integration mode existed.

- Each harness is now one `harnesses/<id>.toml` declaring detection, per-platform config paths, and install modes. The per-client quirks the if/elif chain encoded were four config *shapes*, so they become a closed set of named, individually tested emitters. Six of the fourteen shipped harnesses reuse `mcp_servers` unchanged.
- Verified byte-identical to the old builder across all seven legacy clients and all three Claude scopes before the old code was removed. `mcp_setup` and `client_setup` are now deprecation shims; `mcp config` warns on stderr so `--json` stdout stays parseable.
- Adds `pi`, `hermes`, `opencode`, `goose`, `gemini-cli`, `zed`, `amp`. Goose and Hermes are YAML and Codex is TOML — rather than take a YAML dependency or hand-merge someone's config, those install via their own CLI or print a snippet, enforced by a conformance test.
- Skill discovery derives from the manifests, growing 3 roots → 10 and picking up `~/.claude/skills`, which 0.1 never scanned. Manifests ship in the wheel at `skillroute/_harnesses`.
- `tests/test_harnesses.py` is parametrized over whatever is in `harnesses/`, so a new manifest is covered automatically.

## Scope: this is S0 + S1 of a six-stage release

Against the 0.2 plan, this PR is stages S0 (foundations) and S1 (harness pack engine). Several things look unfinished in isolation but are deliberately owned by later stages — calling them out so review does not read them as defects:

| Looks unfinished | Actually |
| --- | --- |
| `Catalog.record_outcome()` has no caller | `report_outcome` on MCP + ACP is **S6** |
| `route_trace_daily` is written, never read | analytics + `skillroute stats` is **S4** |
| `route_plans` / `skill_projection` tables unused | decomposition is **S6**, projection is **S5**; created now so later stages need no second migration |
| `mcp/` untouched, no attribution handshake | `clientInfo` capture is **S3** |
| `pyproject.toml` still `0.1.0` | publishing is **S2** |

S0 landed all five planned tables under different names: `route_candidates` → `route_trace_candidates`, `route_subtasks` → `route_plans` (plan-level rather than per-subtask rows), `route_daily_rollup` → `route_trace_daily`. Retention default is 20,000 rather than the planned 10,000.

## `b7bc24f` — `harness doctor`

S1 specifies `harness list | detect | install | doctor` and originally shipped without `doctor`. That mattered more than a missing subcommand: the plan names `doctor` as the mitigation for harness path drift, its top risk, and seven of the fourteen packs were written against upstream docs and had never been exercised against the tool itself.

Five checks are static — the manifest declares modes, it has a path for the current platform, the tool is detected, every mode still renders, and the on-disk config names our server. The sixth cannot be faked by inspection: it spawns the exact command the config names, sends an MCP `initialize`, and waits for a JSON-RPC reply. Verified both directions against the real server:

```
ok    server   answered initialize: skillroute 0.1.0
FAIL  server   exit 1: Error: Cannot find module '/private/tmp/mcp/build/index.js'
```

Absent and unconfigured harnesses warn rather than fail, so a non-zero exit means real breakage and `--json --no-probe` works as a CI gate. `platform` is aimed at the specific way v0.1 went wrong — run on Linux or Windows it fails any pack declaring no path there.

## `511cb51`, `d21b90d` — S2 groundwork

v0.1 hardcoded `node <repo>/mcp/build/index.js` into every generated config, which is the concrete reason nothing outside a git checkout can run SkillRoute. `server_argv_for()` makes that an explicit choice between `local` and `npx`, exposed as `--server-source` on `harness show` and `harness install`, and rendering correctly through every emitter including the TOML one.

**`DEFAULT_SERVER_SOURCE` stays `local`, so behavior is unchanged.** Defaulting to npx before `@skillroute/mcp-server` exists would emit configs that resolve to nothing. A test asserts the default, so the flip is a deliberate edit — and that flip is the actual S2 milestone, belonging with the release that publishes the package.

`d21b90d` fixes `cwd = "{repo_root}"` leaking into npx configs for codex and ibm-bob, in the manifests rather than in Python, via a `{server_cwd}` placeholder that renders empty for non-local sources.

## `6d1a94c`, `72bc64d` — release plumbing

npm publish moves from `NPM_TOKEN` to trusted publishing (OIDC), removing the long-lived credential from repo secrets and generating provenance automatically. The non-obvious requirement: trusted publishing needs npm ≥ 11.5.1 and Node 22 bundles npm 10.x, so the job pins Node 22.14.0 and installs `npm@latest` — without that it fails on an error that never mentions the npm version.

Unlike PyPI's pending publishers, npm requires the package to exist before trusted publishing can be configured on it, so `@skillroute/mcp-server@0.1.0` was published by hand to claim the scope.

The build job now fails if the pushed tag disagrees with `pyproject.toml` or `mcp/package.json`. The published version comes from package metadata rather than the tag, so tagging `v0.2.0` against a `0.1.0` pyproject would have published `0.1.0` under a release titled `v0.2.0` — and a PyPI version can never be reused.

`0.2.0` bump covers both versions plus both lockfiles (`npm ci` fails on a lock mismatch). `web/package.json` is untouched — it is private and never published — as is the `0.1.0` in `tests/test_migrations.py`, which describes the schema v0.1.0 actually shipped. `CHANGELOG.md` stays on `[Unreleased]`; converting it stamps a date, and the right date is the tag date.

## Outstanding — one decision, not a defect

- [ ] **Where should a published install keep its catalog?** `default_catalog_path()` resolves to `<repo_root>/.skillroute/catalog.db`, so an npx config still sets a checkout-bound `SKILLROUTE_CATALOG_PATH`. Same class as the `cwd` bug, but the fix moves where user data lives and affects `skillroute index` too, so it is documented in the npx conformance test rather than changed unilaterally. Options: `~/.skillroute/`, an XDG data dir, or per-project with a checkout fallback.
- [ ] Cosmetic: module layout is flat (`harnesses.py` / `harness_render.py` / `harness_setup.py`) rather than the `skillroute/harness/` package the plan sketched, and `tests/test_harnesses.py` rather than `test_harness_manifest.py`. `docs/harnesses.md` describes what actually exists.

## Test plan

- [ ] CI green across Python 3.11 / 3.13 (pytest, ruff, mypy), Web, MCP, Package, CodeQL
- [ ] Coverage gate holds
- [ ] Upgrade check: index with 0.1.0, then run this branch against the same catalog and confirm the v1 → v2 migration preserves traces
- [ ] `skillroute harness show` output byte-identical to `skillroute mcp config` for the seven legacy clients
- [ ] Wheel install resolves all 14 manifests from `skillroute/_harnesses`
