### PR TITLE
chore: follow the repo rename to erichare/skillroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The npm release job publishes via npm trusted publishing (OIDC) instead of a
   long-lived `NPM_TOKEN` secret, so there is no static credential in repo
   secrets to leak or rotate, and provenance attestations are generated
-  automatically. Requires `id-token: write` and npm ≥ 11.5.1, which Node 22 does
-  not bundle — the job upgrades npm explicitly.
+  automatically. Requires `id-token: write` and npm ≥ 11.5.1; the job runs on
+  Node 24, whose bundled npm clears that floor without an install step (Node 22
+  still bundles npm 10.x at its latest patch).
 - The release workflow now fails if the pushed tag disagrees with the version in
   `pyproject.toml` or `mcp/package.json`. The published version comes from
   package metadata rather than the tag, so tagging `v0.2.0` against a `0.1.0`
@@ -118,8 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolve inside it (CodeQL `py/path-injection`). The bundled UI never sent
   `repo`, and the CLI's `--repo` is unaffected.
 
-[Unreleased]: https://github.com/erichare/skill-route/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/erichare/skill-route/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/erichare/skillroute/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/erichare/skillroute/compare/v0.1.0...v0.2.0
 
 ## [0.1.0] - 2026-08-10
 
@@ -143,4 +144,4 @@ First release.
   `skillroute.search`, and `skillroute.inspect_skill`, with client setup via
   `skillroute mcp config --client <client>`
 
-[0.1.0]: https://github.com/erichare/skill-route/releases/tag/v0.1.0
+[0.1.0]: https://github.com/erichare/skillroute/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Index full `SKILL.md` bundles into a local catalog, route any request to ranked
 skills with confidence and evidence, and serve it all to your agents over MCP.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/erichare/skill-route/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/erichare/skill-route/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/erichare/skillroute/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/erichare/skillroute/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](pyproject.toml)
 [![MCP](https://img.shields.io/badge/MCP-stdio%20server-8A2BE2?style=flat-square)](docs/mcp-server.md)
@@ -43,7 +43,7 @@ One guided line (confirms each step, sets up detected agent clients with
 backups):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh | bash
 ```
 
 Or hands-on, in a checkout:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Only the latest release receives security fixes.
 ## Reporting a Vulnerability
 
 Please report vulnerabilities privately via
-[GitHub security advisories](https://github.com/erichare/skill-route/security/advisories/new)
+[GitHub security advisories](https://github.com/erichare/skillroute/security/advisories/new)
 rather than opening a public issue. You should receive a response within a week.
 
 ## Scope notes

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -8,11 +8,11 @@ requests without a hosted service.
 For a fresh SkillRoute install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh | bash
 ```
 
 The installer confirms each step, installs SkillRoute into
-`~/.skillroute/skill-route` by default, builds the MCP server, indexes starter
+`~/.skillroute/skillroute` by default (an existing `skill-route` checkout is reused), builds the MCP server, indexes starter
 skills, detects supported agent clients, and offers setup for each detected
 client. JSON config edits preserve unrelated servers and create timestamped
 backups.
@@ -20,19 +20,19 @@ backups.
 For unattended use:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash -s -- --yes
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh | bash -s -- --yes
 ```
 
 Useful installer options:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh \
   | SKILLROUTE_INSTALL_DIR=/opt/skillroute bash
 
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh \
   | bash -s -- --clients codex,claude-code,vscode --yes
 
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh \
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh \
   | SKILLROUTE_CLIENT_SETUP=0 bash
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,18 +8,18 @@ skills.
 One-line SkillRoute installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh | bash
 ```
 
 The installer confirms each step before it clones or updates SkillRoute,
 installs dependencies, builds the MCP server and Skill Atlas web UI, indexes
 starter skills, detects supported agent clients, and offers setup for each
-detected client. It installs to `~/.skillroute/skill-route` by default.
+detected client. It installs to `~/.skillroute/skillroute` by default, reusing an existing `skill-route` checkout if one is present.
 
 For unattended local/dev use:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash -s -- --yes
+curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh | bash -s -- --yes
 ```
 
 Already in a checkout:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # SkillRoute MCP Server
 
-Stdio MCP server exposing [SkillRoute](https://github.com/erichare/skill-route) routing tools to agent clients: `skillroute.route`, `skillroute.search`, and `skillroute.inspect_skill`.
+Stdio MCP server exposing [SkillRoute](https://github.com/erichare/skillroute) routing tools to agent clients: `skillroute.route`, `skillroute.search`, and `skillroute.inspect_skill`.
 
 The server bridges to the SkillRoute Python package, so install that first:
 
@@ -20,4 +20,4 @@ In a SkillRoute source checkout the server autodetects the repo and runs against
 - `SKILLROUTE_PYTHON` — interpreter to run `-m skillroute` with
 - `SKILLROUTE_BRIDGE_TIMEOUT_MS` — bridge call timeout (default 30000)
 
-See the [main repository](https://github.com/erichare/skill-route) for full documentation, including `skillroute mcp config --client <client>` which generates client configuration for you.
+See the [main repository](https://github.com/erichare/skillroute) for full documentation, including `skillroute mcp config --client <client>` which generates client configuration for you.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -4,14 +4,14 @@
   "description": "SkillRoute MCP stdio server",
   "license": "MIT",
   "author": "Eric Hare",
-  "homepage": "https://github.com/erichare/skill-route#readme",
+  "homepage": "https://github.com/erichare/skillroute#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/erichare/skill-route.git",
+    "url": "git+https://github.com/erichare/skillroute.git",
     "directory": "mcp"
   },
   "bugs": {
-    "url": "https://github.com/erichare/skill-route/issues"
+    "url": "https://github.com/erichare/skillroute/issues"
   },
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/erichare/skill-route"
-Repository = "https://github.com/erichare/skill-route"
-Issues = "https://github.com/erichare/skill-route/issues"
-Changelog = "https://github.com/erichare/skill-route/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/erichare/skillroute"
+Repository = "https://github.com/erichare/skillroute"
+Issues = "https://github.com/erichare/skillroute/issues"
+Changelog = "https://github.com/erichare/skillroute/blob/main/CHANGELOG.md"
 
 [project.scripts]
 skillroute = "skillroute.cli:main"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_URL="${SKILLROUTE_REPO_URL:-https://github.com/erichare/skill-route.git}"
+REPO_URL="${SKILLROUTE_REPO_URL:-https://github.com/erichare/skillroute.git}"
 REF="${SKILLROUTE_REF:-main}"
 INSTALL_DIR="${SKILLROUTE_INSTALL_DIR:-}"
 ASSUME_YES="${SKILLROUTE_ASSUME_YES:-0}"
@@ -31,7 +31,7 @@ SkillRoute installer
 
 Usage:
   scripts/install.sh [options]
-  curl -fsSL https://raw.githubusercontent.com/erichare/skill-route/main/scripts/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/erichare/skillroute/main/scripts/install.sh | bash
 
 Options:
   --yes                 Accept prompts, including detected client setup.
@@ -284,7 +284,15 @@ main() {
     using_current=1
   fi
   if [[ -z "$INSTALL_DIR" ]]; then
-    INSTALL_DIR="$HOME/.skillroute/skill-route"
+    # The repo was renamed skill-route -> skillroute. Keep using an existing
+    # checkout at the old path rather than cloning a second copy: installs from
+    # before the rename have generated MCP configs pointing into it, and those
+    # would silently keep running the stale clone.
+    if [[ -d "$HOME/.skillroute/skill-route" ]]; then
+      INSTALL_DIR="$HOME/.skillroute/skill-route"
+    else
+      INSTALL_DIR="$HOME/.skillroute/skillroute"
+    fi
   fi
   say "Install:    $INSTALL_DIR"
 


### PR DESCRIPTION
The repo moved from `skill-route` to `skillroute`. GitHub redirects the old URLs so nothing is broken today, but every doc link, both package manifests, the CI badge, and the installer's clone URL still named a repo that no longer exists.

Swept: `CHANGELOG.md`, `README.md`, `SECURITY.md`, `docs/agent-setup.md`, `docs/getting-started.md`, `mcp/README.md`, `mcp/package.json`, `pyproject.toml`, `scripts/install.sh` — plus the local git remote.

## The one judgment call

`scripts/install.sh` gets a fallback rather than a straight rename of its default checkout directory:

```bash
if [[ -d "$HOME/.skillroute/skill-route" ]]; then
  INSTALL_DIR="$HOME/.skillroute/skill-route"
else
  INSTALL_DIR="$HOME/.skillroute/skillroute"
fi
```

Installs from before the rename have a clone at the old path *and* generated MCP configs pointing into it. Renaming the default outright would clone a second copy and silently leave those configs running the stale one. New installs get the new path; existing ones are reused in place.

## Also

Corrects a `0.2.0` changelog line describing the npm release job as upgrading npm explicitly — true when written, false by the time `v0.2.0` was tagged. The shipped job runs on Node 24 and installs nothing.

## ⚠️ Needs action outside this repo

The **PyPI and npm trusted publishers are both registered against `erichare/skill-route`** and will reject the next release. Trusted publishing matches the OIDC `repository` claim, which followed the rename immediately.

- PyPI → repository name `skillroute`
- npm → repository `erichare/skillroute`

## Test plan

- [x] 443 tests pass, ruff clean
- [x] `bash -n scripts/install.sh`
- [x] No `erichare/skill-route` references remain; the only `skill-route` strings left are the intentional migration fallback