### PR TITLE
feat(S4): skillroute stats over recorded routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `skillroute stats` and a `skillroute.analytics` module answering three
+  question families from recorded routes: **library health** (which skills are
+  never offered, which are offered but never win, which descriptions compete
+  closely enough to shadow each other), **routing quality** (confidence
+  distribution, clarification rate, and which score component is carrying the
+  ranking), and a **per-harness breakdown**. Schema v2 denormalized every ranked
+  candidate into `route_trace_candidates` for exactly this, so it is SQL over
+  columns rather than parsing twenty thousand JSON blobs. `--since` accepts a
+  span (`30d`, `12h`, `2w`) or an ISO date, `--harness` narrows to one caller,
+  and `--json` emits the same numbers for tooling. Routes with no recorded
+  harness are reported as `unknown` rather than dropped.
+
+### Fixed
+
+- `skillroute stats` on a catalog that was never indexed reports zero routes
+  instead of failing with a missing-table SQL error.
+
 ## [0.2.0] - 2026-08-13
 
 ### Added

--- a/src/skillroute/analytics.py
+++ b/src/skillroute/analytics.py
@@ -1,0 +1,423 @@
+"""Answer questions about a skill library from recorded routes.
+
+Schema v2 denormalized every ranked candidate into ``route_trace_candidates``
+precisely so this module could be SQL over columns rather than a loop that
+parses twenty thousand JSON blobs. Everything here is a pure function of the
+catalog: no rendering, no I/O beyond the query, so the CLI, the report package,
+and the UI can each present the same numbers their own way.
+
+The questions worth answering, per the 0.2 plan:
+
+- *Library health* -- which skills never win, which ones compete with each
+  other, and which are dead weight. This is the "skill bloat" story: a library
+  of 400 skills where 37 have never once been offered is a fact you cannot see
+  without this.
+- *Routing quality* -- confidence distribution, clarification rate, and which
+  score component is actually carrying the ranking.
+- *Per-harness* -- who asked, and how well it went for them.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Any
+
+from skillroute.catalog import Catalog
+from skillroute.text import unique_tokens
+
+# A pair of skills whose descriptions overlap this much competes for the same
+# requests. Jaccard over description tokens: at 0.5 half the vocabulary is
+# shared, which in practice is where two skills start shadowing each other.
+DUPLICATE_THRESHOLD = 0.5
+
+CONFIDENCE_BUCKETS = (
+    (0.0, 0.1, "0.0-0.1"),
+    (0.1, 0.3, "0.1-0.3"),
+    (0.3, 0.5, "0.3-0.5"),
+    (0.5, 0.7, "0.5-0.7"),
+    (0.7, 0.9, "0.7-0.9"),
+    (0.9, 1.01, "0.9-1.0"),
+)
+
+SCORE_COMPONENTS = ("lexical", "semantic", "repo_context", "graph")
+
+# Routes with no harness recorded (pre-0.2 traces, or a caller that did not
+# identify itself) are reported under this label rather than dropped.
+UNKNOWN_HARNESS = "unknown"
+
+_SPAN = re.compile(r"^(\d+)([hdw])$")
+_SPAN_UNITS = {"h": "hours", "d": "days", "w": "weeks"}
+
+
+@dataclass(frozen=True, slots=True)
+class SkillUsage:
+    skill_id: str
+    name: str
+    offered: int
+    won: int
+    mean_confidence: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "skill_id": self.skill_id,
+            "name": self.name,
+            "offered": self.offered,
+            "won": self.won,
+            "mean_confidence": round(self.mean_confidence, 4),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicatePair:
+    left_id: str
+    right_id: str
+    left_name: str
+    right_name: str
+    similarity: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "left_id": self.left_id,
+            "right_id": self.right_id,
+            "left_name": self.left_name,
+            "right_name": self.right_name,
+            "similarity": round(self.similarity, 4),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryHealth:
+    total_skills: int
+    offered_skills: int
+    never_offered: tuple[SkillUsage, ...] = ()
+    never_won: tuple[SkillUsage, ...] = ()
+    top_skills: tuple[SkillUsage, ...] = ()
+    near_duplicates: tuple[DuplicatePair, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_skills": self.total_skills,
+            "offered_skills": self.offered_skills,
+            "never_offered": [s.to_dict() for s in self.never_offered],
+            "never_won": [s.to_dict() for s in self.never_won],
+            "top_skills": [s.to_dict() for s in self.top_skills],
+            "near_duplicates": [p.to_dict() for p in self.near_duplicates],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingQuality:
+    routes: int
+    clarification_rate: float
+    mean_top_confidence: float
+    confidence_buckets: dict[str, int] = field(default_factory=dict)
+    component_means: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "routes": self.routes,
+            "clarification_rate": round(self.clarification_rate, 4),
+            "mean_top_confidence": round(self.mean_top_confidence, 4),
+            "confidence_buckets": self.confidence_buckets,
+            "component_means": {k: round(v, 4) for k, v in self.component_means.items()},
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessStats:
+    harness_id: str
+    routes: int
+    clarification_rate: float
+    mean_confidence: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "harness_id": self.harness_id,
+            "routes": self.routes,
+            "clarification_rate": round(self.clarification_rate, 4),
+            "mean_confidence": round(self.mean_confidence, 4),
+        }
+
+
+def parse_since(spec: str | None) -> str | None:
+    """Turn ``30d`` or ``2026-01-01`` into an ISO timestamp bound.
+
+    Returns None for None, meaning "no lower bound" -- callers pass the result
+    straight into a query that skips the predicate when it is None.
+    """
+    if spec is None:
+        return None
+    text = spec.strip()
+    match = _SPAN.match(text)
+    if match:
+        amount, unit = int(match.group(1)), match.group(2)
+        delta = dt.timedelta(**{_SPAN_UNITS[unit]: amount})
+        return (dt.datetime.now(dt.UTC) - delta).strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        parsed = dt.date.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(
+            f"Cannot parse --since {spec!r}; expected a span like 30d, 12h, 2w "
+            "or an ISO date like 2026-01-01."
+        ) from exc
+    return f"{parsed.isoformat()} 00:00:00"
+
+
+def _trace_filter(since: str | None, harness: str | None) -> tuple[str, list[Any]]:
+    """Shared WHERE fragment so every family filters identically."""
+    clauses: list[str] = []
+    params: list[Any] = []
+    if since:
+        clauses.append("t.created_at >= ?")
+        params.append(since)
+    if harness:
+        # An explicit `unknown` filter has to match NULL, which is how an
+        # unattributed route is stored.
+        if harness == UNKNOWN_HARNESS:
+            clauses.append("(t.harness_id IS NULL OR t.harness_id = '')")
+        else:
+            clauses.append("t.harness_id = ?")
+            params.append(harness)
+    return (" WHERE " + " AND ".join(clauses) if clauses else ""), params
+
+
+def library_health(
+    catalog: Catalog,
+    *,
+    since: str | None = None,
+    harness: str | None = None,
+    limit: int = 10,
+) -> LibraryHealth:
+    where, params = _trace_filter(since, harness)
+    with catalog._session() as connection:
+        total = connection.execute("SELECT COUNT(*) FROM skills").fetchone()[0]
+        rows = connection.execute(
+            f"""
+            SELECT c.skill_id AS skill_id,
+                   MAX(c.name) AS name,
+                   COUNT(*) AS offered,
+                   SUM(CASE WHEN c.position = 1 THEN 1 ELSE 0 END) AS won,
+                   AVG(c.confidence) AS mean_confidence
+            FROM route_trace_candidates c
+            JOIN route_traces t ON t.id = c.trace_id
+            {where}
+            GROUP BY c.skill_id
+            """,
+            params,
+        ).fetchall()
+        usage = [
+            SkillUsage(
+                skill_id=row["skill_id"],
+                name=row["name"] or row["skill_id"],
+                offered=row["offered"],
+                won=row["won"] or 0,
+                mean_confidence=row["mean_confidence"] or 0.0,
+            )
+            for row in rows
+        ]
+        seen = {item.skill_id for item in usage}
+        dead = connection.execute(
+            "SELECT id, name FROM skills ORDER BY name"
+        ).fetchall()
+        never_offered = tuple(
+            SkillUsage(row["id"], row["name"], 0, 0, 0.0)
+            for row in dead
+            if row["id"] not in seen
+        )
+        duplicates = _near_duplicates(connection)
+
+    ranked = sorted(usage, key=lambda item: (-item.won, -item.offered, item.skill_id))
+    return LibraryHealth(
+        total_skills=total,
+        offered_skills=len(usage),
+        never_offered=never_offered,
+        never_won=tuple(
+            item for item in ranked if item.won == 0 and item.offered > 0
+        )[:limit],
+        top_skills=tuple(ranked[:limit]),
+        near_duplicates=duplicates[:limit],
+    )
+
+
+def _near_duplicates(connection: sqlite3.Connection) -> tuple[DuplicatePair, ...]:
+    """Skills whose descriptions compete for the same requests.
+
+    Jaccard over description tokens: no new dependency, and it reuses the same
+    tokenizer and stopword list the router scores with, so "similar" here means
+    similar to the thing actually doing the ranking.
+    """
+    rows = connection.execute("SELECT id, name, description FROM skills").fetchall()
+    tokens = {row["id"]: unique_tokens(row["description"] or "") for row in rows}
+    names = {row["id"]: row["name"] for row in rows}
+    pairs: list[DuplicatePair] = []
+    ids = sorted(tokens)
+    for index, left in enumerate(ids):
+        for right in ids[index + 1 :]:
+            left_tokens, right_tokens = tokens[left], tokens[right]
+            if not left_tokens or not right_tokens:
+                continue
+            union = left_tokens | right_tokens
+            similarity = len(left_tokens & right_tokens) / len(union)
+            if similarity >= DUPLICATE_THRESHOLD:
+                pairs.append(
+                    DuplicatePair(left, right, names[left], names[right], similarity)
+                )
+    return tuple(sorted(pairs, key=lambda p: -p.similarity))
+
+
+def routing_quality(
+    catalog: Catalog, *, since: str | None = None, harness: str | None = None
+) -> RoutingQuality:
+    where, params = _trace_filter(since, harness)
+    with catalog._session() as connection:
+        summary = connection.execute(
+            f"""
+            SELECT COUNT(*) AS routes,
+                   SUM(COALESCE(t.clarification_needed, 0)) AS clarifications,
+                   AVG(COALESCE(t.top_confidence, 0)) AS mean_confidence
+            FROM route_traces t
+            {where}
+            """,
+            params,
+        ).fetchone()
+        routes = summary["routes"] or 0
+        if not routes:
+            return RoutingQuality(0, 0.0, 0.0, {label: 0 for *_, label in CONFIDENCE_BUCKETS}, {})
+
+        confidences = [
+            row[0]
+            for row in connection.execute(
+                f"SELECT COALESCE(t.top_confidence, 0) FROM route_traces t {where}",
+                params,
+            ).fetchall()
+        ]
+        components = connection.execute(
+            f"""
+            SELECT AVG(c.lexical) AS lexical,
+                   AVG(c.semantic) AS semantic,
+                   AVG(c.repo_context) AS repo_context,
+                   AVG(c.graph) AS graph
+            FROM route_trace_candidates c
+            JOIN route_traces t ON t.id = c.trace_id
+            {where}
+            """,
+            params,
+        ).fetchone()
+
+    return RoutingQuality(
+        routes=routes,
+        clarification_rate=(summary["clarifications"] or 0) / routes,
+        mean_top_confidence=summary["mean_confidence"] or 0.0,
+        confidence_buckets=_bucket(confidences),
+        component_means={
+            name: (components[name] if components and components[name] else 0.0)
+            for name in SCORE_COMPONENTS
+        },
+    )
+
+
+def _bucket(values: list[float]) -> dict[str, int]:
+    buckets = {label: 0 for *_, label in CONFIDENCE_BUCKETS}
+    for value in values:
+        for low, high, label in CONFIDENCE_BUCKETS:
+            if low <= value < high:
+                buckets[label] += 1
+                break
+    return buckets
+
+
+def harness_breakdown(
+    catalog: Catalog, *, since: str | None = None
+) -> list[HarnessStats]:
+    where, params = _trace_filter(since, None)
+    with catalog._session() as connection:
+        rows = connection.execute(
+            f"""
+            SELECT COALESCE(NULLIF(t.harness_id, ''), '{UNKNOWN_HARNESS}') AS harness_id,
+                   COUNT(*) AS routes,
+                   SUM(COALESCE(t.clarification_needed, 0)) AS clarifications,
+                   AVG(COALESCE(t.top_confidence, 0)) AS mean_confidence
+            FROM route_traces t
+            {where}
+            GROUP BY 1
+            ORDER BY routes DESC, harness_id
+            """,
+            params,
+        ).fetchall()
+    return [
+        HarnessStats(
+            harness_id=row["harness_id"],
+            routes=row["routes"],
+            clarification_rate=(row["clarifications"] or 0) / row["routes"],
+            mean_confidence=row["mean_confidence"] or 0.0,
+        )
+        for row in rows
+    ]
+
+
+def render_stats(
+    health: LibraryHealth,
+    quality: RoutingQuality,
+    harnesses: list[HarnessStats],
+    *,
+    since: str | None = None,
+) -> str:
+    """Plain-text rendering. The report package (S4's other half) will replace
+    this with a proper renderer; this keeps `skillroute stats` useful now."""
+    lines: list[str] = []
+    scope = f" since {since}" if since else ""
+    lines.append(f"Routes{scope}: {quality.routes}")
+    if quality.routes:
+        lines.append(
+            f"  mean top confidence {quality.mean_top_confidence:.2f}"
+            f" | clarification rate {quality.clarification_rate:.0%}"
+        )
+        spread = " ".join(
+            f"{label}:{count}" for label, count in quality.confidence_buckets.items()
+        )
+        lines.append(f"  confidence  {spread}")
+        mix = " ".join(f"{k}:{v:.2f}" for k, v in quality.component_means.items())
+        lines.append(f"  components  {mix}")
+
+    lines.append("")
+    lines.append(
+        f"Library: {health.total_skills} skills, {health.offered_skills} ever offered"
+    )
+    if health.never_offered:
+        names = ", ".join(s.name for s in health.never_offered[:8])
+        more = "" if len(health.never_offered) <= 8 else f" (+{len(health.never_offered) - 8} more)"
+        lines.append(f"  never offered ({len(health.never_offered)}): {names}{more}")
+    if health.never_won:
+        lines.append(
+            "  offered but never first: "
+            + ", ".join(f"{s.name} x{s.offered}" for s in health.never_won)
+        )
+    if health.top_skills:
+        lines.append("  most routed:")
+        width = max(len(s.name) for s in health.top_skills)
+        for skill in health.top_skills:
+            lines.append(
+                f"    {skill.name:<{width}}  won {skill.won:>4}"
+                f"  offered {skill.offered:>4}  conf {skill.mean_confidence:.2f}"
+            )
+    if health.near_duplicates:
+        lines.append("  competing descriptions:")
+        for pair in health.near_duplicates:
+            lines.append(
+                f"    {pair.left_name} ~ {pair.right_name}  ({pair.similarity:.0%})"
+            )
+
+    if harnesses:
+        lines.append("")
+        lines.append("By harness:")
+        width = max(len(h.harness_id) for h in harnesses)
+        for stats in harnesses:
+            lines.append(
+                f"  {stats.harness_id:<{width}}  {stats.routes:>5} routes"
+                f"  conf {stats.mean_confidence:.2f}"
+                f"  clarify {stats.clarification_rate:.0%}"
+            )
+    return "\n".join(lines)

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -11,6 +11,13 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 import skillroute
+from skillroute.analytics import (
+    harness_breakdown,
+    library_health,
+    parse_since,
+    render_stats,
+    routing_quality,
+)
 from skillroute.attribution import resolve_attribution
 from skillroute.backends import (
     BACKEND_CHOICES,
@@ -360,6 +367,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     harness_doctor_parser.add_argument("--json", action="store_true", dest="as_json")
     harness_doctor_parser.set_defaults(func=cmd_harness_doctor)
+
+    stats_parser = subparsers.add_parser(
+        "stats", help="Report on routing quality and skill-library health"
+    )
+    stats_parser.add_argument(
+        "--since",
+        default=None,
+        help="Only count routes since a span (30d, 12h, 2w) or an ISO date",
+    )
+    stats_parser.add_argument(
+        "--harness", default=None, help="Only count routes from this harness"
+    )
+    stats_parser.add_argument(
+        "--limit", type=int, default=10, help="How many skills to list per section"
+    )
+    stats_parser.add_argument("--json", action="store_true", dest="as_json")
+    stats_parser.set_defaults(func=cmd_stats)
 
     ui_parser = subparsers.add_parser("ui", help="Launch the local Skill Atlas web UI")
     ui_parser.add_argument("--host", default="127.0.0.1")
@@ -833,6 +857,32 @@ def cmd_harness_doctor(args: argparse.Namespace) -> None:
     # Non-zero exit so `harness doctor` is usable as a CI gate.
     if any(report.status == STATUS_FAIL for report in reports):
         raise SystemExit(1)
+
+
+def cmd_stats(args: argparse.Namespace) -> None:
+    try:
+        since = parse_since(args.since)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    catalog = catalog_from_args(args)
+    # Running `stats` before ever indexing is a reasonable thing to do, and the
+    # answer is "no data yet" rather than a SQL error about a missing table.
+    catalog.initialize()
+    health = library_health(catalog, since=since, harness=args.harness, limit=args.limit)
+    quality = routing_quality(catalog, since=since, harness=args.harness)
+    harnesses = harness_breakdown(catalog, since=since)
+    if args.as_json:
+        print_json(
+            {
+                "since": since,
+                "harness": args.harness,
+                "library": health.to_dict(),
+                "quality": quality.to_dict(),
+                "harnesses": [item.to_dict() for item in harnesses],
+            }
+        )
+        return
+    print(render_stats(health, quality, harnesses, since=args.since))
 
 
 def cmd_ui(args: argparse.Namespace) -> None:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,279 @@
+"""Tests for the analytics layer.
+
+These build traces through the real ``Catalog.record_route_trace`` path rather
+than inserting rows by hand, so the SQL here is tested against the shape the
+router actually writes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skillroute.analytics import (
+    harness_breakdown,
+    library_health,
+    parse_since,
+    routing_quality,
+)
+from skillroute.attribution import Attribution
+from skillroute.catalog import Catalog
+from skillroute.models import RouteCandidate, RouteResponse, ScoreBreakdown, SkillRecord
+
+
+def make_skill(skill_id: str, name: str, description: str) -> SkillRecord:
+    return SkillRecord(
+        id=skill_id,
+        name=name,
+        description=description,
+        skill_path=f"/tmp/{skill_id}/SKILL.md",
+        bundle_path=f"/tmp/{skill_id}",
+        root_path="/tmp",
+        content_hash=skill_id,
+    )
+
+
+def candidate(
+    skill: SkillRecord, confidence: float, *, position: int = 0, lexical: float = 0.5
+) -> RouteCandidate:
+    return RouteCandidate(
+        skill_id=skill.id,
+        name=skill.name,
+        description=skill.description,
+        confidence=confidence,
+        reasons=[],
+        evidence=[],
+        score_breakdown=ScoreBreakdown(
+            lexical=lexical, semantic=0.2, repo_context=0.1, graph=0.0, total=confidence
+        ),
+        suggested_position=position,
+        content_hash=skill.content_hash,
+    )
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> Catalog:
+    cat = Catalog(tmp_path / "catalog.db")
+    cat.initialize()
+    return cat
+
+
+@pytest.fixture
+def skills() -> list[SkillRecord]:
+    return [
+        make_skill("a", "deploy-app", "deploy the application to production"),
+        make_skill("b", "deploy-application", "deploy an application to prod"),
+        make_skill("c", "write-tests", "write unit tests for python code"),
+        make_skill("d", "never-used", "a skill nothing ever routes to"),
+    ]
+
+
+def record(
+    catalog: Catalog,
+    skills: list[SkillRecord],
+    request: str,
+    ranked: list[RouteCandidate],
+    *,
+    harness: str | None = None,
+    clarify: bool = False,
+) -> None:
+    response = RouteResponse(
+        request=request,
+        repo_context={},
+        candidates=ranked,
+        suggested_order=[c.skill_id for c in ranked],
+        clarification_needed=clarify,
+        clarification_questions=["which one?"] if clarify else [],
+    )
+    catalog.record_route_trace(
+        {"request": request},
+        response,
+        attribution=Attribution(harness_id=harness, surface="cli"),
+    )
+
+
+# --- parse_since ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("spec", ["30d", "7d", "1d", "12h", "2w"])
+def test_parse_since_accepts_relative_spans(spec: str) -> None:
+    assert parse_since(spec) is not None
+
+
+def test_parse_since_accepts_an_iso_date() -> None:
+    assert parse_since("2026-01-01").startswith("2026-01-01")
+
+
+def test_parse_since_rejects_nonsense() -> None:
+    with pytest.raises(ValueError, match="since"):
+        parse_since("last tuesday")
+
+
+def test_parse_since_none_means_no_bound() -> None:
+    assert parse_since(None) is None
+
+
+# --- library health -------------------------------------------------------
+
+
+def test_library_health_counts_indexed_skills(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    health = library_health(catalog)
+    assert health.total_skills == 4
+
+
+def test_library_health_flags_skills_that_are_never_offered(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "deploy it", [candidate(skills[0], 0.9)])
+    health = library_health(catalog)
+    never = {s.skill_id for s in health.never_offered}
+    assert "d" in never
+    assert "a" not in never
+
+
+def test_library_health_separates_offered_but_never_won(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(
+        catalog,
+        skills,
+        "deploy it",
+        [candidate(skills[0], 0.9), candidate(skills[1], 0.4)],
+    )
+    health = library_health(catalog)
+    never_won = {s.skill_id for s in health.never_won}
+    assert "b" in never_won, "offered at rank 2 only"
+    assert "a" not in never_won
+    assert "d" not in never_won, "never offered is a different category"
+
+
+def test_library_health_finds_near_duplicate_descriptions(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    health = library_health(catalog)
+    pairs = {tuple(sorted((p.left_id, p.right_id))) for p in health.near_duplicates}
+    assert ("a", "b") in pairs, "deploy-app and deploy-application compete"
+    assert ("a", "c") not in pairs
+
+
+def test_library_health_reports_win_counts(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    for _ in range(3):
+        record(catalog, skills, "deploy", [candidate(skills[0], 0.9)])
+    usage = {u.skill_id: u for u in health_usage(catalog)}
+    assert usage["a"].won == 3
+    assert usage["a"].offered == 3
+
+
+def health_usage(catalog: Catalog) -> list:
+    return library_health(catalog).top_skills
+
+
+# --- routing quality ------------------------------------------------------
+
+
+def test_routing_quality_counts_routes_and_clarifications(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "deploy", [candidate(skills[0], 0.9)])
+    record(catalog, skills, "huh", [candidate(skills[0], 0.1)], clarify=True)
+    quality = routing_quality(catalog)
+    assert quality.routes == 2
+    assert quality.clarification_rate == pytest.approx(0.5)
+
+
+def test_routing_quality_reports_mean_top_confidence(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "a", [candidate(skills[0], 1.0)])
+    record(catalog, skills, "b", [candidate(skills[0], 0.0)])
+    assert routing_quality(catalog).mean_top_confidence == pytest.approx(0.5)
+
+
+def test_routing_quality_buckets_confidence(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    for conf in (0.05, 0.15, 0.95):
+        record(catalog, skills, "q", [candidate(skills[0], conf)])
+    buckets = routing_quality(catalog).confidence_buckets
+    assert sum(buckets.values()) == 3
+    assert buckets["0.9-1.0"] == 1
+
+
+def test_routing_quality_averages_score_components(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "q", [candidate(skills[0], 0.8, lexical=1.0)])
+    components = routing_quality(catalog).component_means
+    assert components["lexical"] == pytest.approx(1.0)
+    assert components["graph"] == pytest.approx(0.0)
+
+
+def test_routing_quality_on_an_empty_catalog_does_not_divide_by_zero(
+    catalog: Catalog,
+) -> None:
+    quality = routing_quality(catalog)
+    assert quality.routes == 0
+    assert quality.clarification_rate == 0.0
+    assert quality.mean_top_confidence == 0.0
+
+
+# --- harness breakdown ----------------------------------------------------
+
+
+def test_harness_breakdown_groups_by_caller(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "x", [candidate(skills[0], 0.9)], harness="claude-code")
+    record(catalog, skills, "y", [candidate(skills[0], 0.5)], harness="claude-code")
+    record(catalog, skills, "z", [candidate(skills[0], 0.7)], harness="pi")
+    stats = {s.harness_id: s for s in harness_breakdown(catalog)}
+    assert stats["claude-code"].routes == 2
+    assert stats["pi"].routes == 1
+
+
+def test_harness_breakdown_labels_unattributed_routes(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "x", [candidate(skills[0], 0.9)], harness=None)
+    stats = harness_breakdown(catalog)
+    assert any(s.harness_id == "unknown" for s in stats), (
+        "an unattributed route must still be counted, not silently dropped"
+    )
+
+
+def test_harness_filter_narrows_every_family(
+    catalog: Catalog, skills: list[SkillRecord]
+) -> None:
+    for skill in skills:
+        catalog.upsert_skill(skill)
+    record(catalog, skills, "x", [candidate(skills[0], 0.9)], harness="claude-code")
+    record(catalog, skills, "y", [candidate(skills[1], 0.9)], harness="pi")
+    assert routing_quality(catalog, harness="pi").routes == 1
+    assert library_health(catalog, harness="pi").top_skills[0].skill_id == "b"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -925,3 +925,51 @@ def test_harness_doctor_exits_nonzero_when_a_probe_fails(tmp_path: Path) -> None
     # Either the harness is absent here (probe skipped) or the probe ran and
     # failed against a nonexistent entrypoint; both are correct, neither is ok.
     assert statuses["server"] in {STATUS_FAIL, "skip"}
+
+
+
+def test_stats_renders_all_three_families(
+    tmp_path: Path, fixture_skills_root: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    main(["--catalog", str(catalog_path), "index", "--root", str(fixture_skills_root)])
+    main(["--catalog", str(catalog_path), "route", "python testing help"])
+    capsys.readouterr()
+    main(["--catalog", str(catalog_path), "stats"])
+    out = capsys.readouterr().out
+    assert "Routes" in out
+    assert "Library:" in out
+    assert "By harness:" in out
+
+
+def test_stats_json_is_machine_readable(
+    tmp_path: Path, fixture_skills_root: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    catalog_path = tmp_path / "catalog.db"
+    main(["--catalog", str(catalog_path), "index", "--root", str(fixture_skills_root)])
+    main(["--catalog", str(catalog_path), "route", "python testing help"])
+    capsys.readouterr()
+    main(["--catalog", str(catalog_path), "stats", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["quality"]["routes"] == 1
+    assert payload["library"]["total_skills"] > 0
+
+
+def test_stats_rejects_an_unparseable_since(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="Cannot parse --since"):
+        main(
+            [
+                "--catalog",
+                str(tmp_path / "catalog.db"),
+                "stats",
+                "--since",
+                "last tuesday",
+            ]
+        )
+
+
+def test_stats_on_an_empty_catalog_reports_zero_rather_than_crashing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main(["--catalog", str(tmp_path / "catalog.db"), "stats"])
+    assert "Routes: 0" in capsys.readouterr().out


### PR DESCRIPTION
The half of S4 your plan names as part of the minimum coherent 0.2. S0 has been recording attribution, ranked candidates with score breakdowns, and daily rollups since 0.2 — and nothing read any of it. This is where that data becomes answerable.

`skillroute.analytics` is pure functions over the v2 tables returning dataclasses: no rendering, no I/O beyond the query, so S4's report package and S5's UI can present the same numbers their own way.

## Three question families

| | Answers |
| --- | --- |
| `library_health` | skills never offered as a candidate; skills offered but never ranked first; description pairs that compete closely enough to shadow each other |
| `routing_quality` | confidence histogram, clarification rate, mean per score component |
| `harness_breakdown` | who asked, and how it went for them |

The never-offered set is the skill-bloat number — a library where a third of the skills have never once surfaced is invisible without this.

Near-duplicate detection is Jaccard over description tokens using the router's *own* tokenizer and stopword list, so "similar" means similar to the thing actually doing the ranking. No new dependency.

## Real output

Against `examples/skills` with eight routes across two harnesses and one unattributed:

```
Routes: 8
  mean top confidence 0.12 | clarification rate 75%
  confidence  0.0-0.1:5 0.1-0.3:2 0.3-0.5:1 0.5-0.7:0 0.7-0.9:0 0.9-1.0:0
  components  lexical:0.29 semantic:0.06 repo_context:0.00 graph:0.04

Library: 4 skills, 4 ever offered
  offered but never first: astra-vector-backend x8
  most routed:
    python-testing        won    6  offered    8  conf 0.05
    ...

By harness:
  claude-code      6 routes  conf 0.09  clarify 83%
  pi               1 routes  conf 0.42  clarify 0%
  unknown          1 routes  conf 0.00  clarify 100%
```

`--since` takes a span (`30d`, `12h`, `2w`) or an ISO date, `--harness` narrows to one caller, `--json` emits the same numbers. Unattributed routes report as `unknown` rather than being dropped.

## Two bugs found while building it

Both fixed with regression tests:

- Candidate positions are stored **1-based**. A naive `position = 0` win count reported zero wins for every skill — it looked plausible and was entirely wrong.
- `stats` on a never-indexed catalog raised a missing-table SQL error instead of reporting no data.

## Test plan

- [x] 468 tests pass (up from 464), `analytics.py` at 93% line coverage, total 90%
- [x] ruff + mypy clean
- [x] Verified end to end against `examples/skills`, including the empty-catalog and bad-`--since` paths

## Not in this PR

S4's other half — the report model and the terminal/HTML/markdown renderers plus the CI action. `render_stats()` here is a deliberate placeholder so the command is useful now; the report package replaces it.