### PR TITLE
docs: record why the repo-root containment check looks unsafe

### DIFF
--- a/src/skillroute/context.py
+++ b/src/skillroute/context.py
@@ -47,6 +47,17 @@ def resolve_repo_within(repo: str | Path, root: Path) -> Path:
     Relative paths are taken against ``root``. Resolution happens before the
     containment check, so ``..`` segments and symlinks pointing outside are
     caught rather than smuggled through.
+
+    CodeQL reports ``py/path-injection`` on the ``resolve()`` below and it is a
+    false positive: this function is the sanitizer, and the resolved value only
+    reaches a caller after ``is_relative_to`` passes. CodeQL does not model
+    ``is_relative_to`` as a barrier.
+
+    Do not rewrite this as a ``startswith`` prefix check to appease the scanner.
+    That pattern is what CodeQL recognises, and it is strictly weaker here: a
+    sibling directory sharing the root's name as a prefix (``/root-evil`` for a
+    root of ``/root``) passes a prefix test and is correctly rejected by
+    ``is_relative_to``. ``tests/test_context.py`` covers that case.
     """
     candidate = Path(repo).expanduser()
     if not candidate.is_absolute():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -86,3 +86,21 @@ def test_resolve_repo_within_rejects_symlink_escape(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="must stay inside"):
         resolve_repo_within(root / "sneaky", root)
+
+
+def test_resolve_repo_within_rejects_a_sibling_sharing_the_root_prefix(
+    tmp_path: Path,
+) -> None:
+    """The case that makes is_relative_to stronger than a startswith check.
+
+    CodeQL flags this function as py/path-injection because it does not model
+    is_relative_to as a barrier. Rewriting the check as a string prefix test to
+    satisfy the scanner would let this path through.
+    """
+    root = tmp_path / "root"
+    root.mkdir()
+    sibling = tmp_path / "root-evil"
+    sibling.mkdir()
+    assert str(sibling).startswith(str(root)), "precondition: shares the prefix"
+    with pytest.raises(ValueError, match="must stay inside"):
+        resolve_repo_within(sibling, root)


### PR DESCRIPTION
CodeQL alert #2 reported `py/path-injection` on the `resolve()` inside `resolve_repo_within`. I've **dismissed it as a false positive** — the security page is now clean — and this PR records why, plus a test that stops the obvious "fix" from landing.

## Why it's a false positive

`resolve_repo_within` *is* the sanitizer, added in `c12daf4` to close the original route-preview path injection. It resolves first (collapsing `..` and symlinks), then enforces containment with `Path.is_relative_to` and raises — the value only reaches a caller after that check passes. CodeQL doesn't model `is_relative_to` as a barrier.

Verified by probing it directly before dismissing. All rejected:

```
../outside          ../../etc           /etc/passwd
<absolute outside>  link -> outside     link/secret.txt
~                   sub/../../outside   /tmp/.../root-evil
```

## Why not just satisfy the scanner

CodeQL *does* recognise `startswith`-style prefix guards. Rewriting to that pattern would clear the alert and **introduce a real hole**: a sibling directory whose name extends the root's — `/root-evil` against a root of `/root` — passes a prefix test and is correctly rejected by `is_relative_to`.

So the scanner-friendly version is strictly weaker. That's worth writing down at the function, because the next person to see a red security page will reach for exactly that change.

## What's here

- A docstring note explaining the false positive and naming the trap
- `test_resolve_repo_within_rejects_a_sibling_sharing_the_root_prefix` — asserts the shared-prefix precondition, then asserts rejection, so the weaker rewrite **fails CI** rather than being discouraged by a comment

## Test plan

- [x] `tests/test_context.py` — 10 tests pass (was 9)
- [x] ruff clean
- [x] Code scanning: 0 open alerts