### PR TITLE
feat: default the catalog to ~/.skillroute/catalog.db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The default catalog is now `~/.skillroute/catalog.db` instead of
+  `.skillroute/catalog.db` under the working directory. v0.1 and v0.2 resolved
+  it against a checkout, which was fine when a git clone was the only way to run
+  SkillRoute; since 0.2 publishes to PyPI and npm, `uvx skillroute` has no
+  checkout and a checkout-relative default names a directory that does not
+  exist. An **existing** project catalog still wins, so anyone who indexed into
+  their checkout keeps using it rather than finding an empty library.
+  `--catalog` and `SKILLROUTE_CATALOG_PATH` are unchanged and still take
+  precedence.
+- Generated configs for a published server (`--server-source npx`) now point at
+  the user catalog rather than resolving one against the checkout that happened
+  to generate them. This was the last checkout-bound path in an npx config.
+
 ### Added
 
 - `skillroute stats` and a `skillroute.analytics` module answering three
@@ -124,8 +139,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `skillroute harness install`. Output is unchanged and the deprecation
   notice goes to stderr, so `--json` stdout stays machine-parseable. The
   `skillroute.client_setup` and `skillroute.mcp_setup` modules are now shims
-  re-exporting `skillroute.harness_setup` and `skillroute.harness_render`. All
-  are removed in 0.3.
+  re-exporting `skillroute.harness_setup` and `skillroute.harness_render`. They
+  are removed in a later release; 0.3 keeps them.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Ranked skills:
 
 </details>
 
-The default catalog lives at `.skillroute/catalog.db`; point elsewhere with
+The default catalog lives at `~/.skillroute/catalog.db`. A `.skillroute/catalog.db`
+in the working directory is used instead when one already exists, so existing
+project catalogs keep working; point elsewhere with
 `--catalog <path>` or `SKILLROUTE_CATALOG_PATH`.
 
 ## Skill Atlas

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,8 @@ The web build is required before `skillroute ui` can serve the Skill Atlas.
 uv run skillroute index --root examples/skills
 ```
 
-This creates `.skillroute/catalog.db` in the current directory unless you pass
+This creates `~/.skillroute/catalog.db` unless a `.skillroute/catalog.db` already
+exists in the current directory, in which case that one is used. Override with
 `--catalog` or set `SKILLROUTE_CATALOG_PATH`.
 
 ## Route A Request

--- a/src/skillroute/catalog.py
+++ b/src/skillroute/catalog.py
@@ -137,11 +137,35 @@ def max_route_traces() -> int:
     return MAX_ROUTE_TRACES
 
 
+def user_catalog_path() -> Path:
+    """The catalog a machine-wide install uses: ``~/.skillroute/catalog.db``.
+
+    Matches where the installer already keeps its checkout (``~/.skillroute/``),
+    so SkillRoute owns one directory in $HOME rather than two.
+    """
+    return (Path.home() / ".skillroute" / "catalog.db").resolve()
+
+
 def default_catalog_path(base: Path | None = None) -> Path:
+    """Where to read or write the catalog when the caller did not say.
+
+    v0.1 and v0.2 resolved this against the working directory, which was fine
+    when a git checkout was the only way to run SkillRoute. Since 0.2 publishes
+    to PyPI and npm, `uvx skillroute` has no checkout at all and a
+    checkout-relative default names a directory that does not exist.
+
+    So the default is now user-scoped -- except that an *existing* project
+    catalog still wins. Anyone who indexed into their checkout under 0.1 or 0.2
+    keeps using it; switching them to an empty catalog under $HOME would look
+    exactly like their library disappearing.
+    """
     configured = os.environ.get("SKILLROUTE_CATALOG_PATH")
     if configured:
         return Path(configured).expanduser().resolve()
-    return ((base or Path.cwd()) / ".skillroute" / "catalog.db").resolve()
+    project = ((base or Path.cwd()) / ".skillroute" / "catalog.db").resolve()
+    if project.exists():
+        return project
+    return user_catalog_path()
 
 
 class Catalog:

--- a/src/skillroute/harness_render.py
+++ b/src/skillroute/harness_render.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from skillroute.catalog import default_catalog_path
+from skillroute.catalog import default_catalog_path, user_catalog_path
 from skillroute.harnesses import (
     HarnessManifest,
     InstallMode,
@@ -105,14 +105,23 @@ def build_harness_setup(
     resolved_scope = _resolve_scope(install, scope, harness=harness)
     resolved_platform = platform or current_platform()
     resolved_repo_root = (repo_root or default_repo_root()).expanduser().resolve()
+    resolved_source = server_source or DEFAULT_SERVER_SOURCE
+    # A published server has no checkout, so resolving its catalog against one
+    # would bake in a path that does not exist on the machine running the
+    # config. Only a `local` config may name the checkout's catalog.
     catalog_path = (
-        catalog.expanduser().resolve() if catalog else default_catalog_path(resolved_repo_root)
+        catalog.expanduser().resolve()
+        if catalog
+        else (
+            default_catalog_path(resolved_repo_root)
+            if resolved_source == "local"
+            else user_catalog_path()
+        )
     )
     selected_backend = (
         backend or os.environ.get("SKILLROUTE_BACKEND") or "local"
     ).strip().lower()
     entrypoint = local_entrypoint(resolved_repo_root)
-    resolved_source = server_source or DEFAULT_SERVER_SOURCE
     argv = (
         list(server_argv)
         if server_argv

--- a/tests/test_catalog_path.py
+++ b/tests/test_catalog_path.py
@@ -1,0 +1,149 @@
+"""Where the catalog lives.
+
+v0.1 and v0.2 resolved the catalog relative to the working directory, which was
+fine when the only way to run SkillRoute was from a git checkout. Since 0.2
+publishes to PyPI and npm, a user can `uvx skillroute` with no checkout at all,
+and a checkout-relative default points at a directory that does not exist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skillroute.catalog import default_catalog_path, user_catalog_path
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SKILLROUTE_CATALOG_PATH", raising=False)
+
+
+def test_user_catalog_path_is_under_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert user_catalog_path() == (tmp_path / ".skillroute" / "catalog.db").resolve()
+
+
+def test_env_var_still_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "explicit" / "catalog.db"
+    monkeypatch.setenv("SKILLROUTE_CATALOG_PATH", str(target))
+    assert default_catalog_path() == target.resolve()
+    assert default_catalog_path(tmp_path / "elsewhere") == target.resolve()
+
+
+def test_default_is_the_user_catalog_when_no_project_catalog_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    assert default_catalog_path(project) == (home / ".skillroute" / "catalog.db").resolve()
+
+
+def test_an_existing_project_catalog_still_wins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Anyone who indexed into their checkout keeps using it.
+
+    Silently switching them to an empty catalog under $HOME would look like
+    their whole library vanished.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    (project / ".skillroute").mkdir(parents=True)
+    existing = project / ".skillroute" / "catalog.db"
+    existing.write_bytes(b"")
+    monkeypatch.setenv("HOME", str(home))
+    assert default_catalog_path(project) == existing.resolve()
+
+
+def test_project_fallback_uses_cwd_when_no_base_is_given(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    (project / ".skillroute").mkdir(parents=True)
+    (project / ".skillroute" / "catalog.db").write_bytes(b"")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(project)
+    assert default_catalog_path() == (project / ".skillroute" / "catalog.db").resolve()
+
+
+def test_a_project_directory_without_a_catalog_does_not_capture_the_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty .skillroute/ dir is not a catalog."""
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    (project / ".skillroute").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    assert default_catalog_path(project) == (home / ".skillroute" / "catalog.db").resolve()
+
+
+# --- generated configs ----------------------------------------------------
+
+
+def test_published_configs_never_point_at_a_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The bug this change exists to fix.
+
+    An npx-resolved server has no checkout, so its catalog must not be resolved
+    against one -- even when the machine generating the config has one.
+    """
+    from skillroute.harness_render import build_harness_setup
+
+    home = tmp_path / "home"
+    home.mkdir()
+    repo = tmp_path / "checkout"
+    (repo / ".skillroute").mkdir(parents=True)
+    (repo / ".skillroute" / "catalog.db").write_bytes(b"")
+    monkeypatch.setenv("HOME", str(home))
+
+    payload = build_harness_setup(
+        harness="claude-code", mode="mcp", repo_root=repo, server_source="npx"
+    )
+    catalog = payload["server_config"]["env"]["SKILLROUTE_CATALOG_PATH"]
+    assert str(repo) not in catalog
+    assert catalog == str((home / ".skillroute" / "catalog.db").resolve())
+
+
+def test_local_configs_still_use_the_checkout_catalog(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from skillroute.harness_render import build_harness_setup
+
+    home = tmp_path / "home"
+    home.mkdir()
+    repo = tmp_path / "checkout"
+    (repo / ".skillroute").mkdir(parents=True)
+    (repo / ".skillroute" / "catalog.db").write_bytes(b"")
+    monkeypatch.setenv("HOME", str(home))
+
+    payload = build_harness_setup(
+        harness="claude-code", mode="mcp", repo_root=repo, server_source="local"
+    )
+    catalog = payload["server_config"]["env"]["SKILLROUTE_CATALOG_PATH"]
+    assert catalog == str((repo / ".skillroute" / "catalog.db").resolve())
+
+
+def test_an_explicit_catalog_argument_overrides_both(tmp_path: Path) -> None:
+    from skillroute.harness_render import build_harness_setup
+
+    explicit = tmp_path / "chosen.db"
+    payload = build_harness_setup(
+        harness="claude-code",
+        mode="mcp",
+        repo_root=tmp_path,
+        catalog=explicit,
+        server_source="npx",
+    )
+    assert payload["server_config"]["env"]["SKILLROUTE_CATALOG_PATH"] == str(
+        explicit.resolve()
+    )


### PR DESCRIPTION
The carried-over decision from S2, now that it's no longer theoretical: since 0.2 publishes to PyPI and npm, a real user can `uvx skillroute` with no checkout — and a checkout-relative catalog default names a directory that doesn't exist on their machine.

## The change

Default is now `~/.skillroute/catalog.db`, matching where the installer already keeps its clone, so SkillRoute owns one directory in `$HOME` rather than two.

**An existing project catalog still wins.** Anyone who indexed into their checkout under 0.1 or 0.2 keeps using it — silently switching them to an empty catalog under `$HOME` is indistinguishable from their whole library disappearing. An empty `.skillroute/` directory doesn't count; the catalog file has to exist, so a stray directory can't capture the default.

`--catalog` and `SKILLROUTE_CATALOG_PATH` are unchanged and still take precedence over both.

## Also fixes the last checkout-bound path in published configs

`build_harness_setup` resolved the catalog *before* it knew the server source, so an `--server-source npx` config inherited a catalog path from whatever checkout generated it. Source is now resolved first, and only a `local` config may name the checkout's catalog.

Verified in this repo, which has a real `.skillroute/catalog.db`:

```
local config → /Users/…/skill-route/.skillroute/catalog.db
npx config   → /Users/…/.skillroute/catalog.db
```

## Also

Softens the 0.2.0 changelog line promising the `mcp_setup`/`client_setup` shims are removed in 0.3 — they aren't, per your call not to let SemVer force the removal. Released notes shouldn't state something false.

## Test plan

- [x] 478 tests pass (up from 469), ruff + mypy clean
- [x] New `tests/test_catalog_path.py` — 9 tests covering env precedence, user default, project fallback, the empty-`.skillroute/` case, cwd-relative resolution, and both server sources
- [x] Docs updated: `README.md`, `docs/getting-started.md`