### PR TITLE
feat: move fastapi and uvicorn to a `ui` extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`fastapi` and `uvicorn` moved to a `ui` extra; a plain install now has zero
+  runtime dependencies.** They are used only by `skillroute ui`, which imports
+  them lazily, so every other command was paying for them. The cost was not
+  abstract: `fastapi` pulls `pydantic-core`, a Rust extension, so a Homebrew
+  formula needed a Rust toolchain and a from-source compile to install a tool
+  that is otherwise pure stdlib. Install the UI with `pip install
+  'skillroute[ui]'` or `uvx --from 'skillroute[ui]' skillroute ui`; `skillroute
+  ui` without it now explains that instead of raising an import error. The
+  `dev` extra includes `ui`, so nothing changes for contributors.
+
+### Changed
+
 - The default catalog is now `~/.skillroute/catalog.db` instead of
   `.skillroute/catalog.db` under the working directory. v0.1 and v0.2 resolved
   it against a checkout, which was fine when a git clone was the only way to run

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ flowchart LR
 ## Development
 
 ```bash
-uv sync --extra dev
+uv sync --extra dev   # dev includes the `ui` extra
 uv run --extra dev pytest --cov=skillroute
 uv run --extra dev ruff check . && uv run --extra dev mypy
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ commands for supported clients.
 Manual setup is also supported:
 
 ```bash
-uv sync --extra dev
+uv sync --extra dev   # dev includes the `ui` extra
 npm --prefix mcp ci
 npm --prefix mcp run build
 npm --prefix web ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,24 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Typing :: Typed",
 ]
-dependencies = [
+# Deliberately empty. Routing, indexing, search, stats, and harness setup are
+# stdlib-only; fastapi and uvicorn are needed by `skillroute ui` alone and live
+# in the `ui` extra so a plain install stays dependency-free. This is not
+# cosmetic: fastapi pulls pydantic-core, a Rust extension, which every install
+# that never opens the UI would otherwise have to fetch or compile.
+dependencies = []
+
+[project.optional-dependencies]
+ui = [
     "fastapi>=0.141.1",
     "uvicorn>=0.52.1",
 ]
-
-[project.optional-dependencies]
 dev = [
     "httpx>=0.27.0",
     "mypy>=2.3.0",
     "pytest>=8.0.0",
     "ruff>=0.16.2",
+    "skillroute[ui]",
 ]
 
 [project.urls]

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -885,8 +885,23 @@ def cmd_stats(args: argparse.Namespace) -> None:
     print(render_stats(health, quality, harnesses, since=args.since))
 
 
+UI_EXTRA_MISSING = (
+    "The Skill Atlas UI needs the `ui` extra, which is not installed.\n"
+    "  uv:   uv pip install 'skillroute[ui]'\n"
+    "  pip:  pip install 'skillroute[ui]'\n"
+    "  uvx:  uvx --from 'skillroute[ui]' skillroute ui\n"
+    "Everything else (route, index, search, stats, harness) needs no extras."
+)
+
+
 def cmd_ui(args: argparse.Namespace) -> None:
-    from skillroute.ui_server import run_ui
+    # Imported here, not at module scope, so the whole CLI does not depend on
+    # fastapi being installed. A missing extra should read as a missing extra,
+    # not as a traceback about a module nobody asked the user to install.
+    try:
+        from skillroute.ui_server import run_ui
+    except ImportError as exc:
+        raise SystemExit(UI_EXTRA_MISSING) from exc
 
     run_ui(
         catalog_path=args.catalog,

--- a/src/skillroute/ui_server.py
+++ b/src/skillroute/ui_server.py
@@ -8,6 +8,17 @@ import webbrowser
 from pathlib import Path
 from typing import Any
 
+# These live in the `ui` extra, so importing this module without it fails --
+# by design. The ImportError is deliberately left to propagate: a library
+# caller should see the ordinary Python error naming the missing package, and
+# `cmd_ui` catches it to print install instructions for a CLI user. Raising
+# SystemExit here instead would kill an embedding process and hide the cause.
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
 import skillroute
 from skillroute.atlas import (
     build_atlas_payload,
@@ -19,18 +30,6 @@ from skillroute.backends import backend_from_name
 from skillroute.catalog import Catalog, default_catalog_path
 from skillroute.context import REPO_ROOT_ENV, allowed_repo_root, resolve_repo_within
 from skillroute.routing import Router
-
-try:
-    import uvicorn
-    from fastapi import FastAPI, HTTPException
-    from fastapi.responses import FileResponse
-    from fastapi.staticfiles import StaticFiles
-    from pydantic import BaseModel, Field
-except ImportError as exc:  # pragma: no cover - exercised only in misconfigured installs.
-    raise SystemExit(
-        "The SkillRoute UI requires FastAPI and Uvicorn. "
-        "Run `uv sync --extra dev` or reinstall SkillRoute."
-    ) from exc
 
 
 class RoutePreviewRequest(BaseModel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -973,3 +973,21 @@ def test_stats_on_an_empty_catalog_reports_zero_rather_than_crashing(
 ) -> None:
     main(["--catalog", str(tmp_path / "catalog.db"), "stats"])
     assert "Routes: 0" in capsys.readouterr().out
+
+
+def test_ui_reports_a_missing_extra_instead_of_an_import_traceback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """fastapi/uvicorn live in the `ui` extra, so this path is reachable."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fail_ui_server(name: str, *args: object, **kwargs: object) -> object:
+        if name == "skillroute.ui_server":
+            raise ImportError("No module named 'fastapi'")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fail_ui_server)
+    with pytest.raises(SystemExit, match=r"skillroute\[ui\]"):
+        main(["--catalog", str(tmp_path / "c.db"), "ui", "--no-open"])

--- a/uv.lock
+++ b/uv.lock
@@ -680,17 +680,19 @@ wheels = [
 name = "skillroute"
 version = "0.2.0"
 source = { editable = "." }
-dependencies = [
-    { name = "fastapi" },
-    { name = "uvicorn" },
-]
 
 [package.optional-dependencies]
 dev = [
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "uvicorn" },
+]
+ui = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -700,14 +702,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.141.1" },
+    { name = "fastapi", marker = "extra == 'ui'", specifier = ">=0.141.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.2" },
-    { name = "uvicorn", specifier = ">=0.52.1" },
+    { name = "skillroute", extras = ["ui"], marker = "extra == 'dev'" },
+    { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.52.1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["ui", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-cov", specifier = ">=7.1.0" }]


### PR DESCRIPTION
A plain `pip install skillroute` now has **zero runtime dependencies**.

## Why

`fastapi` and `uvicorn` are used by exactly one module — `ui_server` — which `cmd_ui` imports lazily. So `route`, `index`, `search`, `stats`, `harness`, and `bridge` have always been paying for a web framework they never touch.

The cost isn't aesthetic. The chain is:

```
fastapi → pydantic → pydantic-core (Rust) → maturin → needs a Rust toolchain
```

Homebrew builds every resource from source, so packaging a tool that is otherwise pure stdlib required a Rust toolchain and a from-source compile. The tap's first build failed outright on exactly this. After this change the formula needs **no resources at all**.

## Also fixes a competing error path

`ui_server` converted the ImportError into `SystemExit` — process-killing for a library caller, and it hid the cause. The natural ImportError now propagates and `cmd_ui` catches it. Previously the two paths raced and the stale `ui_server` message won, telling users to run `uv sync --extra dev` — advice that doesn't apply to an installed package.

Before / after in a bare venv:

```
- The SkillRoute UI requires FastAPI and Uvicorn. Run `uv sync --extra dev` or reinstall SkillRoute.
+ The Skill Atlas UI needs the `ui` extra, which is not installed.
+   uv:   uv pip install 'skillroute[ui]'
+   pip:  pip install 'skillroute[ui]'
+   uvx:  uvx --from 'skillroute[ui]' skillroute ui
+ Everything else (route, index, search, stats, harness) needs no extras.
```

## Contributors are unaffected

`dev` depends on `skillroute[ui]`, so `uv run --frozen --extra dev` still resolves fastapi — verified, since CI depends on it and a broken self-reference would have been silent until CI ran.

## Test plan

- [x] 479 tests, ruff + mypy clean
- [x] `uv run --frozen --extra dev` (exactly what CI runs) resolves fastapi/uvicorn
- [x] Bare venv: `pip install skillroute` installs **only** `skillroute==0.2.0`; `--version` and `harness list` work; `ui` prints the install lines
- [x] New test asserts the CLI raises `SystemExit` mentioning `skillroute[ui]` rather than an import traceback

## Note on the Homebrew tap

The tap still pins 0.2.0, which declares the deps, so it keeps its 13 resources and `depends_on "rust" => :build` for now — verified still building and installing. Once 0.3.0 ships I'll swap it for the zero-resource formula, which drops the Rust dependency entirely.