### PR TITLE
feat: Agent Skills open-standard compliance — validate, index gate, spec fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent Skills spec compliance.** SkillRoute now treats the
+  [Agent Skills](https://agentskills.io/home) open standard as a first-class
+  contract rather than an informal shape. New `skillroute validate [paths]`
+  checks SKILL.md bundles against the
+  [specification](https://agentskills.io/specification): the frontmatter MUSTs
+  (required `name`/`description`, the 64/1024/500-character bounds, the name
+  charset and parent-directory match, `metadata` as a string map,
+  `allowed-tools` as a space-separated string) are errors, and the
+  progressive-disclosure recommendations (description quality, body size,
+  reference depth) are warnings. `--strict` fails on warnings too, `--json`
+  emits a machine-readable report, and a non-zero exit on errors makes it
+  usable as a CI gate. See [docs/spec-compliance.md](docs/spec-compliance.md).
+- `skillroute index` validates every bundle it discovers. Errors are reported
+  on stderr and the bundle is indexed anyway by default; `--strict` refuses
+  non-compliant bundles so a catalog stays spec-clean by construction.
+- `skillroute inspect` surfaces the optional spec fields (`license`,
+  `compatibility`, `allowed-tools`, and the `metadata` map) when a bundle
+  declares them. They were already stored with the catalog record; now they
+  are visible.
 - `deepseek` harness: emit a `cordis.patch.yml` MCP insert for DeepSeek
   Harness (`dsh`), which loads MCP servers through its
   `@deepseek-ai/dsh-mcp-client` plugin. A new `dsh_cordis_patch` emitter

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ SkillRoute treats your skill library like a real corpus:
 - **Local first** — one SQLite file, no services to run. Add the Astra DB
   backend when you outgrow it.
 
+## Built on the Agent Skills open standard
+
+SkillRoute is built around [Agent Skills](https://agentskills.io/home), the
+open standard for `SKILL.md` bundles. Every bundle you index is checked
+against the [specification](https://agentskills.io/specification), and a
+standalone validator doubles as a CI gate for skill authors:
+
+```bash
+uv run skillroute validate examples/skills          # report
+uv run skillroute validate --strict                 # fail on warnings too
+uv run skillroute index --root examples/skills --strict   # refuse non-compliant bundles
+```
+
+```text
+Spec check (https://agentskills.io/specification): 4 bundles, 0 errors, 0 warnings
+```
+
+See [Spec Compliance](docs/spec-compliance.md) for the full rule set.
+
 ## Quick start
 
 One guided line (confirms each step, sets up detected agent clients with
@@ -165,6 +184,7 @@ flowchart LR
 | `skillroute route "<request>"` | Ranked skills with confidence and evidence |
 | `skillroute search "<query>"` | Hybrid search across the catalog |
 | `skillroute inspect <skill>` | Metadata, relationships, excerpts, sources |
+| `skillroute validate [paths]` | Check bundles against the Agent Skills spec |
 | `skillroute traces list` | Inspect past routing decisions |
 | `skillroute eval run` | Golden-route evals against expected outcomes |
 | `skillroute backend status` | Retrieval backend health |
@@ -177,6 +197,7 @@ flowchart LR
 | Guide | |
 | --- | --- |
 | [Getting Started](docs/getting-started.md) | Index, route, and inspect in five minutes |
+| [Spec Compliance](docs/spec-compliance.md) | Validate bundles against the Agent Skills spec |
 | [Harness Packs](docs/harnesses.md) | Supported harnesses, install modes, and how to add one |
 | [Agent Setup](docs/agent-setup.md) | Wire SkillRoute into your agent clients |
 | [MCP Server](docs/mcp-server.md) | Tools, transport, and configuration |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,15 @@ This creates `~/.skillroute/catalog.db` unless a `.skillroute/catalog.db` alread
 exists in the current directory, in which case that one is used. Override with
 `--catalog` or set `SKILLROUTE_CATALOG_PATH`.
 
+Every bundle is checked against the [Agent Skills
+specification](https://agentskills.io/specification) as it is indexed; run the
+validator on its own for the full report, or pass `--strict` to refuse
+non-compliant bundles:
+
+```bash
+uv run skillroute validate examples/skills
+```
+
 ## Route A Request
 
 ```bash

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -1,0 +1,101 @@
+# Agent Skills Spec Compliance
+
+SkillRoute is built around the [Agent Skills](https://agentskills.io/home) open
+standard: a skill is a folder containing a `SKILL.md` with YAML frontmatter
+(`name` and `description`, at minimum) plus optional `scripts/`,
+`references/`, and `assets/` directories. The
+[specification](https://agentskills.io/specification) defines the frontmatter
+contract and the progressive-disclosure guidance that makes skills load
+cheaply across agents.
+
+Routing a library you cannot trust is guesswork with extra steps, so
+SkillRoute checks every bundle against the spec — as a standalone command, and
+on every indexing run.
+
+## `skillroute validate`
+
+```bash
+skillroute validate                      # scan . recursively
+skillroute validate examples/skills      # scan a root
+skillroute validate ./my-skill           # one bundle directory
+skillroute validate ./my-skill/SKILL.md  # one file
+skillroute validate --strict             # fail on warnings too
+skillroute validate --json               # machine-readable report
+```
+
+Every bundle is reported against the spec with two severities:
+
+- **error** — violates a spec MUST. The bundle is not portable;
+  spec-conforming clients are entitled to refuse it. `validate` exits
+  non-zero, so it works as a CI gate.
+- **warning** — violates a spec recommendation. The bundle loads, but the
+  guidance exists because real agents degrade on it (overlong files crowd the
+  context window; thin descriptions route poorly).
+
+```text
+$ skillroute validate ./skills
+skills/BadName/SKILL.md
+  error[name]: name 'Bad_Name' must match the parent directory name 'BadName'
+  error[metadata]: metadata value 'stable' must be a string; quote it (e.g. stable: "true")
+  warning[references]: reference 'references/legal/REFERENCE.md' is more than one level deep; ...
+Spec check (https://agentskills.io/specification): 12 bundles, 2 errors, 1 warning
+```
+
+## What is checked
+
+Errors (the spec's MUSTs):
+
+| Field | Rule |
+| --- | --- |
+| frontmatter | `SKILL.md` opens with a `---` YAML block |
+| `name` | Required; 1–64 characters; lowercase `a-z`, `0-9`, `-` only; no leading, trailing, or consecutive hyphens; matches the parent directory name |
+| `description` | Required, non-empty, ≤ 1024 characters |
+| `compatibility` | ≤ 500 characters when present |
+| `metadata` | A mapping of string keys to string values (quote numbers and booleans) |
+| `allowed-tools` | A space-separated string, not a YAML list (experimental field) |
+
+Warnings (the spec's recommendations):
+
+- `description` long enough to say what the skill does **and** when to use it
+- `SKILL.md` body under 500 lines / ~5000 tokens (estimated) — move detail
+  into `references/`
+- File references one level deep from `SKILL.md`, never escaping the bundle
+
+Unknown top-level frontmatter fields are **not** flagged. The spec defines
+its six fields but does not forbid others, and SkillRoute's own extensions
+(`tags`, `requires`, `complements`, …) are load-bearing. For data meant to
+travel between ecosystems, prefer the spec's `metadata` map.
+
+## Spec checks during indexing
+
+`skillroute index` validates every bundle it discovers:
+
+- By default, errors and warnings are reported on stderr and the bundle is
+  indexed anyway — SkillRoute routes the library you have, not the library
+  you wish you had.
+- `skillroute index --root <dir> --strict` refuses bundles with spec errors,
+  so a catalog can be kept compliant by construction.
+
+```text
+$ skillroute index --root examples/skills
+Indexed 4 skills into /Users/you/.skillroute/catalog.db
+# (stderr, when findings exist)
+skillroute: spec check on examples/skills: 0 errors, 2 warnings across 4 bundles ...
+```
+
+## Spec fields in the catalog
+
+The optional spec fields are indexed with the bundle and surfaced by
+`skillroute inspect` (and in `--json` output, the MCP `inspect_skill` tool,
+and the Atlas detail data): `license`, `compatibility`, `allowed-tools`, and
+the `metadata` map.
+
+## Relationship to `skills-ref`
+
+The spec points at the reference validator (`skills-ref validate
+./my-skill`). SkillRoute's checker is dependency-free and built in, so it
+runs anywhere SkillRoute runs — including inside `index` — without a separate
+install. If you already use `skills-ref`, both tools check the same
+frontmatter contract; `skillroute validate` adds the routing-relevant
+advisories (description quality, body size) that SkillRoute is in a position
+to care about.

--- a/src/skillroute/catalog.py
+++ b/src/skillroute/catalog.py
@@ -32,6 +32,7 @@ from skillroute.models import (
 )
 from skillroute.overlays import load_overlays, overlay_for_skill
 from skillroute.parser import discover_skill_files, parse_frontmatter, parse_skill_bundle
+from skillroute.spec import SkillSpecReport, summarize_reports, validate_skill_file
 
 SCHEMA_VERSION = 2
 
@@ -168,6 +169,42 @@ def default_catalog_path(base: Path | None = None) -> Path:
     return user_catalog_path()
 
 
+def _report_spec_summary(root: Path, reports: list[SkillSpecReport], *, spec_strict: bool) -> None:
+    """Surface Agent Skills spec findings from an indexing run.
+
+    Errors are named individually (a non-compliant bundle is not portable, so
+    it should never pass silently); warnings are counted only, with
+    `skillroute validate` as the tool for working through them. Everything
+    goes to stderr so stdout stays reserved for the command's actual output.
+    """
+    summary = summarize_reports(reports)
+    if not summary["errors"] and not summary["warnings"]:
+        return
+    shown = 0
+    for report in reports:
+        for finding in report.errors:
+            if shown >= 5:
+                break
+            print(
+                f"skillroute: spec error[{finding.field}] {report.skill_path}: "
+                f"{finding.message}",
+                file=sys.stderr,
+            )
+            shown += 1
+        if shown >= 5:
+            break
+    remaining = summary["errors"] - shown
+    if remaining > 0:
+        print(f"skillroute: ... and {remaining} more spec errors", file=sys.stderr)
+    action = "non-compliant bundles refused" if spec_strict else "bundles with errors indexed"
+    print(
+        f"skillroute: spec check on {root}: {summary['errors']} errors, "
+        f"{summary['warnings']} warnings across {summary['bundles']} bundles "
+        f"({action}; run `skillroute validate {root}` for details)",
+        file=sys.stderr,
+    )
+
+
 class Catalog:
     def __init__(self, path: Path | str | None = None) -> None:
         self.path = Path(path).expanduser().resolve() if path else default_catalog_path()
@@ -262,12 +299,27 @@ class Catalog:
             ).fetchone()
             return int(row[0]) if row else None
 
-    def index_root(self, root: Path | str) -> list[SkillRecord]:
+    def index_root(self, root: Path | str, *, spec_strict: bool = False) -> list[SkillRecord]:
         root_path = Path(root).expanduser().resolve()
         overlays = load_overlays(root_path)
         skills: list[SkillRecord] = []
+        spec_reports: list[SkillSpecReport] = []
         for skill_file in discover_skill_files(root_path):
             try:
+                # Every bundle is checked against the Agent Skills spec as it
+                # is indexed. Errors are reported (and, with spec_strict, the
+                # bundle is refused) because a non-compliant skill is not
+                # portable across clients; warnings are summarized only --
+                # `skillroute validate` is the tool for working through them.
+                report = validate_skill_file(skill_file)
+                spec_reports.append(report)
+                if spec_strict and report.errors:
+                    print(
+                        f"skillroute: refusing spec-noncompliant bundle {skill_file} "
+                        f"({len(report.errors)} errors)",
+                        file=sys.stderr,
+                    )
+                    continue
                 raw_text = skill_file.read_text(encoding="utf-8")
                 metadata, _ = parse_frontmatter(raw_text)
                 name = str(metadata.get("name") or skill_file.parent.name)
@@ -276,6 +328,7 @@ class Catalog:
             except (OSError, ValueError, KeyError) as exc:
                 # Isolate failures so one malformed SKILL.md cannot abort the run.
                 print(f"skillroute: skipping {skill_file}: {exc}", file=sys.stderr)
+        _report_spec_summary(root_path, spec_reports, spec_strict=spec_strict)
         self.replace_root(root_path, skills)
         for backend_ref in LocalTokenBackend().upsert_skills(skills):
             self.save_backend_ref(

--- a/src/skillroute/cli.py
+++ b/src/skillroute/cli.py
@@ -62,6 +62,13 @@ from skillroute.metadata import (
 )
 from skillroute.models import to_jsonable
 from skillroute.routing import Router
+from skillroute.spec import (
+    SPEC_URL,
+    render_report_lines,
+    report_to_dict,
+    summarize_reports,
+    validate_target,
+)
 from skillroute.tuning import tune_weights
 
 # Resolved once at import so argparse `choices` stay in sync with the manifests
@@ -89,6 +96,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     index_parser = subparsers.add_parser("index", help="Index SKILL.md bundles under a root")
     index_parser.add_argument("--root", type=Path, required=True)
+    index_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Refuse bundles that fail the Agent Skills spec check instead of "
+        "indexing them with a warning",
+    )
     add_backend_argument(index_parser)
     index_parser.set_defaults(func=cmd_index)
 
@@ -116,6 +129,25 @@ def build_parser() -> argparse.ArgumentParser:
     inspect_parser.add_argument("skill_id")
     inspect_parser.add_argument("--json", action="store_true", dest="as_json")
     inspect_parser.set_defaults(func=cmd_inspect)
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Check SKILL.md bundles against the Agent Skills spec (agentskills.io)",
+    )
+    validate_parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        metavar="PATH",
+        help="SKILL.md files, bundle directories, or roots to scan (default: .)",
+    )
+    validate_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on warnings as well as errors",
+    )
+    validate_parser.add_argument("--json", action="store_true", dest="as_json")
+    validate_parser.set_defaults(func=cmd_validate)
 
     eval_parser = subparsers.add_parser("eval", help="Run eval commands")
     eval_subparsers = eval_parser.add_subparsers(dest="eval_command", required=True)
@@ -429,7 +461,7 @@ def router_from_args(catalog: Catalog, args: argparse.Namespace) -> Router:
 def cmd_index(args: argparse.Namespace) -> None:
     catalog = catalog_from_args(args)
     backend = backend_from_args(args)
-    skills = catalog.index_root(args.root)
+    skills = catalog.index_root(args.root, spec_strict=args.strict)
     print(f"Indexed {len(skills)} skills into {catalog.path}")
     refs: list[dict[str, Any]]
     if isinstance(backend, SqliteFTS5Backend):
@@ -492,6 +524,12 @@ def cmd_inspect(args: argparse.Namespace) -> None:
     print(f"{skill.name} ({skill.id})")
     print(skill.description)
     print(f"path: {skill.skill_path}")
+    for spec_field in ("license", "compatibility", "allowed-tools"):
+        value = skill.metadata.get(spec_field)
+        if value:
+            print(f"{spec_field}: {value}")
+    if isinstance(skill.metadata.get("metadata"), dict):
+        print(f"metadata: {json.dumps(skill.metadata['metadata'], sort_keys=True)}")
     if skill.tags:
         print(f"tags: {', '.join(skill.tags)}")
     if skill.facets:
@@ -504,6 +542,39 @@ def cmd_inspect(args: argparse.Namespace) -> None:
         print("excerpts:")
         for excerpt in skill.excerpts:
             print(f"  [{excerpt.kind}] {excerpt.text}")
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    paths = args.paths or [Path(".")]
+    reports = []
+    for path in paths:
+        reports.extend(validate_target(path))
+    summary = summarize_reports(reports)
+    if args.as_json:
+        print_json(
+            {
+                "spec": SPEC_URL,
+                "summary": summary,
+                "reports": [report_to_dict(report) for report in reports],
+            }
+        )
+    else:
+        if not reports:
+            print(f"No SKILL.md bundles found under: {', '.join(str(path) for path in paths)}")
+        for report in reports:
+            lines = render_report_lines(report)
+            if lines:
+                print(report.skill_path)
+                for line in lines:
+                    print(line)
+        print(
+            f"Spec check ({SPEC_URL}): {summary['bundles']} bundles, "
+            f"{summary['errors']} errors, {summary['warnings']} warnings"
+        )
+    # Non-zero exit makes validate usable as a CI gate; --strict also fails
+    # on warnings, for libraries that want the recommendations enforced.
+    if summary["errors"] or (args.strict and summary["warnings"]):
+        raise SystemExit(1)
 
 
 def cmd_eval_run(args: argparse.Namespace) -> None:

--- a/src/skillroute/spec.py
+++ b/src/skillroute/spec.py
@@ -1,0 +1,356 @@
+"""Validate SKILL.md bundles against the Agent Skills open specification.
+
+The spec (https://agentskills.io/specification) defines the SKILL.md
+frontmatter contract: required ``name`` and ``description`` fields with
+concrete constraints, the optional ``license``, ``compatibility``,
+``metadata``, and ``allowed-tools`` fields, and progressive-disclosure
+guidance (keep the main file short, keep file references shallow). This
+module checks those rules with no third-party dependencies, so it runs
+everywhere SkillRoute does -- including in CI as a gate.
+
+Findings are two-valued:
+
+- ``error`` violates a spec MUST. A bundle with errors is not portable:
+  spec-conforming clients are entitled to refuse it.
+- ``warning`` violates a spec recommendation. The bundle still loads, but
+  the guidance exists because real agents degrade on it (overlong files
+  crowd the context window; thin descriptions route poorly).
+
+Unknown top-level frontmatter fields are not flagged. The spec defines the
+six fields above but does not forbid others, and SkillRoute's own extensions
+(tags, relationships) are load-bearing. The spec's answer for portable extra
+data is the ``metadata`` map; see docs/spec-compliance.md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from skillroute.parser import FRONTMATTER_RE, MARKDOWN_LINK_RE, parse_frontmatter
+
+SPEC_URL = "https://agentskills.io/specification"
+
+ERROR = "error"
+WARNING = "warning"
+SEVERITIES = (ERROR, WARNING)
+
+# Field constraints, straight from the spec's frontmatter table.
+NAME_MAX = 64
+NAME_RE = re.compile(r"\A[a-z0-9-]+\Z")
+DESCRIPTION_MAX = 1024
+COMPATIBILITY_MAX = 500
+
+# Progressive-disclosure guidance. The spec recommends keeping SKILL.md under
+# 500 lines and the activated load under ~5000 tokens; tokens are estimated
+# at four characters each, which is the usual approximation for prose.
+BODY_LINE_TARGET = 500
+BODY_TOKEN_TARGET = 5000
+TOKEN_CHAR_ESTIMATE = 4
+
+# The spec's poor example ("Helps with PDFs.") is 16 characters; descriptions
+# under this length almost never answer both "what it does" and "when to use
+# it", which is what the description is for. Advisory only.
+DESCRIPTION_SOFT_MIN = 50
+
+SPEC_FIELDS = ("name", "description", "license", "compatibility", "metadata", "allowed-tools")
+
+
+@dataclass(slots=True)
+class SpecFinding:
+    severity: str
+    field: str
+    message: str
+
+
+@dataclass(slots=True)
+class SkillSpecReport:
+    skill_path: str
+    bundle_path: str
+    name: str | None
+    findings: list[SpecFinding] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[SpecFinding]:
+        return [finding for finding in self.findings if finding.severity == ERROR]
+
+    @property
+    def warnings(self) -> list[SpecFinding]:
+        return [finding for finding in self.findings if finding.severity == WARNING]
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+
+def validate_root(root: Path | str) -> list[SkillSpecReport]:
+    """Validate every SKILL.md bundle discovered under a root directory."""
+    root_path = Path(root).expanduser().resolve()
+    return [
+        validate_skill_file(skill_file)
+        for skill_file in sorted(root_path.rglob("SKILL.md"))
+        if skill_file.is_file()
+    ]
+
+
+def validate_target(path: Path | str) -> list[SkillSpecReport]:
+    """Validate a SKILL.md file, a single bundle directory, or a whole root.
+
+    A directory containing its own SKILL.md is one bundle; any other
+    directory is scanned recursively. This is what `skillroute validate`
+    applies to each of its path arguments.
+    """
+    target = Path(path).expanduser().resolve()
+    if target.is_file():
+        return [validate_skill_file(target)]
+    if (target / "SKILL.md").is_file():
+        return [validate_skill_file(target / "SKILL.md")]
+    return validate_root(target)
+
+
+def validate_skill_file(skill_file: Path | str) -> SkillSpecReport:
+    skill_path = Path(skill_file).expanduser().resolve()
+    report = SkillSpecReport(
+        skill_path=str(skill_path),
+        bundle_path=str(skill_path.parent),
+        name=None,
+    )
+    text = skill_path.read_text(encoding="utf-8")
+    if not FRONTMATTER_RE.match(text):
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "frontmatter",
+                "SKILL.md must open with a YAML frontmatter block (--- ... ---) "
+                "declaring at least name and description",
+            )
+        )
+        metadata: dict[str, Any] = {}
+        body = text
+    else:
+        metadata, body = parse_frontmatter(text)
+
+    _check_name(report, metadata.get("name"))
+    _check_description(report, metadata.get("description"))
+    _check_compatibility(report, metadata.get("compatibility"))
+    _check_metadata_map(report, metadata.get("metadata"))
+    _check_allowed_tools(report, metadata.get("allowed-tools"))
+    _check_body(report, body)
+    return report
+
+
+def _check_name(report: SkillSpecReport, value: Any) -> None:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        report.findings.append(SpecFinding(ERROR, "name", "name is required"))
+        return
+    if not isinstance(value, str):
+        report.findings.append(
+            SpecFinding(ERROR, "name", f"name must be a string, got {type(value).__name__}")
+        )
+        return
+    name = value.strip()
+    report.name = name
+    if len(name) > NAME_MAX:
+        report.findings.append(
+            SpecFinding(ERROR, "name", f"name is {len(name)} characters; the maximum is {NAME_MAX}")
+        )
+    if not NAME_RE.match(name):
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "name",
+                "name may only contain lowercase letters, numbers, and hyphens",
+            )
+        )
+    if name.startswith("-") or name.endswith("-"):
+        report.findings.append(
+            SpecFinding(ERROR, "name", "name must not start or end with a hyphen")
+        )
+    if "--" in name:
+        report.findings.append(
+            SpecFinding(ERROR, "name", "name must not contain consecutive hyphens")
+        )
+    directory = Path(report.bundle_path).name
+    if name != directory:
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "name",
+                f"name {name!r} must match the parent directory name {directory!r}",
+            )
+        )
+
+
+def _check_description(report: SkillSpecReport, value: Any) -> None:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        report.findings.append(SpecFinding(ERROR, "description", "description is required"))
+        return
+    if not isinstance(value, str):
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "description",
+                f"description must be a string, got {type(value).__name__}",
+            )
+        )
+        return
+    description = value.strip()
+    if len(description) > DESCRIPTION_MAX:
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "description",
+                f"description is {len(description)} characters; the maximum is {DESCRIPTION_MAX}",
+            )
+        )
+    if len(description) < DESCRIPTION_SOFT_MIN:
+        report.findings.append(
+            SpecFinding(
+                WARNING,
+                "description",
+                "description is short; the spec recommends describing both what the "
+                "skill does and when to use it, with keywords an agent can match on",
+            )
+        )
+
+
+def _check_compatibility(report: SkillSpecReport, value: Any) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str):
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "compatibility",
+                f"compatibility must be a string, got {type(value).__name__}",
+            )
+        )
+        return
+    if len(value.strip()) > COMPATIBILITY_MAX:
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "compatibility",
+                f"compatibility is {len(value.strip())} characters; the maximum is "
+                f"{COMPATIBILITY_MAX}",
+            )
+        )
+
+
+def _check_metadata_map(report: SkillSpecReport, value: Any) -> None:
+    if value is None:
+        return
+    # parse_simple_yaml leaves a bare `metadata:` line as an empty list.
+    if value == []:
+        return
+    if not isinstance(value, dict):
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "metadata",
+                f"metadata must be a key-value mapping, got {type(value).__name__}",
+            )
+        )
+        return
+    for key, item in value.items():
+        if not isinstance(item, str):
+            rendered = str(item).lower() if isinstance(item, bool) else str(item)
+            report.findings.append(
+                SpecFinding(
+                    ERROR,
+                    "metadata",
+                    f"metadata value {key!r} must be a string; quote it "
+                    f"(e.g. {key}: \"{rendered}\")",
+                )
+            )
+
+
+def _check_allowed_tools(report: SkillSpecReport, value: Any) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str):
+        report.findings.append(
+            SpecFinding(
+                ERROR,
+                "allowed-tools",
+                "allowed-tools must be a space-separated string "
+                "(e.g. 'Bash(git:*) Read'), not a YAML list",
+            )
+        )
+
+
+def _check_body(report: SkillSpecReport, body: str) -> None:
+    lines = body.splitlines()
+    if len(lines) > BODY_LINE_TARGET:
+        report.findings.append(
+            SpecFinding(
+                WARNING,
+                "body",
+                f"SKILL.md body is {len(lines)} lines; the spec recommends under "
+                f"{BODY_LINE_TARGET} -- move detail into referenced files",
+            )
+        )
+    estimated_tokens = len(body) // TOKEN_CHAR_ESTIMATE
+    if estimated_tokens > BODY_TOKEN_TARGET:
+        report.findings.append(
+            SpecFinding(
+                WARNING,
+                "body",
+                f"SKILL.md body is ~{estimated_tokens} tokens (estimated); the spec "
+                f"recommends under {BODY_TOKEN_TARGET} once activated",
+            )
+        )
+    _check_references(report, body)
+
+
+def _check_references(report: SkillSpecReport, body: str) -> None:
+    flagged: set[str] = set()
+    for match in MARKDOWN_LINK_RE.finditer(body):
+        target = match.group("target").split("#", 1)[0].strip()
+        if not target or "://" in target or target.startswith("mailto:"):
+            continue
+        if target.startswith(("/", "..")):
+            flagged.add(f"reference {target!r} points outside the skill bundle")
+            continue
+        # "One level deep from SKILL.md": references/REFERENCE.md is fine,
+        # references/legal/REFERENCE.md asks the agent to follow a chain.
+        parent_dirs = len(Path(target).parts) - 1
+        if parent_dirs > 1:
+            flagged.add(
+                f"reference {target!r} is more than one level deep; the spec "
+                "recommends keeping file references one level from SKILL.md"
+            )
+    for message in sorted(flagged):
+        report.findings.append(SpecFinding(WARNING, "references", message))
+
+
+def summarize_reports(reports: list[SkillSpecReport]) -> dict[str, int]:
+    return {
+        "bundles": len(reports),
+        "ok": sum(1 for report in reports if report.ok),
+        "errors": sum(len(report.errors) for report in reports),
+        "warnings": sum(len(report.warnings) for report in reports),
+    }
+
+
+def report_to_dict(report: SkillSpecReport) -> dict[str, Any]:
+    return {
+        "skill_path": report.skill_path,
+        "bundle_path": report.bundle_path,
+        "name": report.name,
+        "ok": report.ok,
+        "findings": [
+            {"severity": finding.severity, "field": finding.field, "message": finding.message}
+            for finding in report.findings
+        ],
+    }
+
+
+def render_report_lines(report: SkillSpecReport) -> list[str]:
+    """One line per finding; nothing for a clean bundle."""
+    return [
+        f"  {finding.severity}[{finding.field}]: {finding.message}"
+        for finding in report.findings
+    ]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -225,3 +225,27 @@ def test_index_root_skips_malformed_skill(tmp_path: Path, capsys) -> None:
     assert "good-skill" in names
     assert len(skills) == 1
     assert "skipping" in capsys.readouterr().err
+
+
+def test_index_root_spec_strict_refuses_noncompliant_bundles(tmp_path: Path, capsys) -> None:
+    compliant = tmp_path / "compliant-skill"
+    compliant.mkdir()
+    (compliant / "SKILL.md").write_text(
+        "---\nname: compliant-skill\n"
+        "description: A compliant skill with a real description of what it does.\n---\n\n# C\n",
+        encoding="utf-8",
+    )
+    noncompliant = tmp_path / "wrong-dir"
+    noncompliant.mkdir()
+    (noncompliant / "SKILL.md").write_text(
+        "---\nname: different-name\ndescription: Name does not match the parent directory.\n---\n",
+        encoding="utf-8",
+    )
+
+    catalog = Catalog(tmp_path / "catalog.db")
+    skills = catalog.index_root(tmp_path, spec_strict=True)
+
+    assert [skill.name for skill in skills] == ["compliant-skill"]
+    err = capsys.readouterr().err
+    assert "refusing spec-noncompliant bundle" in err
+    assert "spec check" in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -991,3 +991,107 @@ def test_ui_reports_a_missing_extra_instead_of_an_import_traceback(
     monkeypatch.setattr(builtins, "__import__", fail_ui_server)
     with pytest.raises(SystemExit, match=r"skillroute\[ui\]"):
         main(["--catalog", str(tmp_path / "c.db"), "ui", "--no-open"])
+
+
+def _write_spec_skill(root: Path, directory: str, text: str) -> None:
+    bundle = root / directory
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "SKILL.md").write_text(text, encoding="utf-8")
+
+
+GOOD_SPEC_SKILL = (
+    "---\n"
+    "name: {name}\n"
+    "description: Extracts text and tables from PDF files. Use when handling PDFs.\n"
+    "---\n\n# {name}\n\nInstructions.\n"
+)
+
+
+def test_cli_validate_clean_root_exits_zero(tmp_path: Path, capsys) -> None:
+    _write_spec_skill(tmp_path, "pdf-processing", GOOD_SPEC_SKILL.format(name="pdf-processing"))
+    main(["validate", str(tmp_path)])
+    output = capsys.readouterr().out
+    assert "1 bundles, 0 errors, 0 warnings" in output
+
+
+def test_cli_validate_fails_on_errors(tmp_path: Path, capsys) -> None:
+    _write_spec_skill(tmp_path, "Bad_Name", "---\nname: Bad_Name\n---\n\n# Bad\n")
+    with pytest.raises(SystemExit) as exc_info:
+        main(["validate", str(tmp_path)])
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "error[name]" in output
+    assert "error[description]" in output
+    assert "agentskills.io/specification" in output
+
+
+def test_cli_validate_strict_fails_on_warnings(tmp_path: Path) -> None:
+    _write_spec_skill(
+        tmp_path,
+        "pdf-processing",
+        GOOD_SPEC_SKILL.format(name="pdf-processing").replace(
+            "Extracts text and tables from PDF files. Use when handling PDFs.", "Helps with PDFs."
+        ),
+    )
+    main(["validate", str(tmp_path)])  # warnings alone do not fail
+    with pytest.raises(SystemExit) as exc_info:
+        main(["validate", str(tmp_path), "--strict"])
+    assert exc_info.value.code == 1
+
+
+def test_cli_validate_json(tmp_path: Path, capsys) -> None:
+    _write_spec_skill(tmp_path, "pdf-processing", GOOD_SPEC_SKILL.format(name="pdf-processing"))
+    main(["validate", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["spec"] == "https://agentskills.io/specification"
+    assert payload["summary"]["bundles"] == 1
+    assert payload["reports"][0]["ok"] is True
+
+
+def test_cli_validate_defaults_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _write_spec_skill(tmp_path, "pdf-processing", GOOD_SPEC_SKILL.format(name="pdf-processing"))
+    monkeypatch.chdir(tmp_path)
+    main(["validate", "--strict"])
+    assert "0 errors, 0 warnings" in capsys.readouterr().out
+
+
+def test_cli_index_warns_but_indexes_noncompliant_bundles(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "skills"
+    _write_spec_skill(root, "ok-skill", GOOD_SPEC_SKILL.format(name="ok-skill"))
+    _write_spec_skill(root, "bad-skill", "# no frontmatter\n")
+    main(["--catalog", str(tmp_path / "catalog.db"), "index", "--root", str(root)])
+    captured = capsys.readouterr()
+    assert "Indexed 2 skills" in captured.out
+    assert "spec check" in captured.err
+
+
+def test_cli_index_strict_refuses_noncompliant_bundles(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "skills"
+    _write_spec_skill(root, "ok-skill", GOOD_SPEC_SKILL.format(name="ok-skill"))
+    _write_spec_skill(root, "bad-skill", "# no frontmatter\n")
+    main(["--catalog", str(tmp_path / "catalog.db"), "index", "--root", str(root), "--strict"])
+    captured = capsys.readouterr()
+    assert "Indexed 1 skills" in captured.out
+    assert "refusing spec-noncompliant bundle" in captured.err
+
+
+def test_cli_inspect_surfaces_spec_fields(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "skills"
+    _write_spec_skill(
+        root,
+        "pdf-processing",
+        GOOD_SPEC_SKILL.format(name="pdf-processing").replace(
+            "---\n\n",
+            "license: Apache-2.0\ncompatibility: Requires Python 3.14+\n"
+            "metadata:\n  author: example-org\n---\n\n",
+            1,
+        ),
+    )
+    catalog_path = tmp_path / "catalog.db"
+    main(["--catalog", str(catalog_path), "index", "--root", str(root)])
+    capsys.readouterr()
+    main(["--catalog", str(catalog_path), "inspect", "pdf-processing"])
+    output = capsys.readouterr().out
+    assert "license: Apache-2.0" in output
+    assert "compatibility: Requires Python 3.14+" in output
+    assert 'metadata: {"author": "example-org"}' in output

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skillroute.spec import (
+    ERROR,
+    WARNING,
+    summarize_reports,
+    validate_root,
+    validate_skill_file,
+    validate_target,
+)
+
+GOOD_DESCRIPTION = "Extracts text and tables from PDF files. Use when working with PDF documents."
+
+
+def write_skill(root: Path, directory: str, text: str) -> Path:
+    bundle = root / directory
+    bundle.mkdir(parents=True, exist_ok=True)
+    skill_file = bundle / "SKILL.md"
+    skill_file.write_text(text, encoding="utf-8")
+    return skill_file
+
+
+def minimal_bundle(name: str, description: str = GOOD_DESCRIPTION) -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\nInstructions.\n"
+
+
+def fields(report, severity=None) -> list[tuple[str, str]]:
+    return [
+        (finding.severity, finding.field)
+        for finding in report.findings
+        if severity is None or finding.severity == severity
+    ]
+
+
+def test_valid_minimal_bundle_is_clean(tmp_path: Path) -> None:
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle("pdf-processing"))
+    report = validate_skill_file(skill_file)
+    assert report.ok
+    assert report.name == "pdf-processing"
+
+
+def test_valid_full_bundle_is_clean(tmp_path: Path) -> None:
+    text = (
+        "---\n"
+        "name: pdf-processing\n"
+        f"description: {GOOD_DESCRIPTION}\n"
+        "license: Apache-2.0\n"
+        "compatibility: Requires Python 3.14+ and uv\n"
+        "metadata:\n"
+        "  author: example-org\n"
+        '  version: "1.0"\n'
+        "allowed-tools: Bash(git:*) Bash(jq:*) Read\n"
+        "---\n\n# PDF Processing\n\nSee [the reference](references/REFERENCE.md).\n"
+    )
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    assert validate_skill_file(skill_file).ok
+
+
+def test_missing_frontmatter_is_an_error(tmp_path: Path) -> None:
+    skill_file = write_skill(tmp_path, "pdf-processing", "# No frontmatter\n\nJust prose.\n")
+    report = validate_skill_file(skill_file)
+    assert (ERROR, "frontmatter") in fields(report)
+    assert (ERROR, "name") in fields(report)
+    assert (ERROR, "description") in fields(report)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["PDF-Processing", "-pdf", "pdf-", "pdf--processing", "pdf_processing", "Pdf"],
+)
+def test_invalid_names_are_errors(tmp_path: Path, name: str) -> None:
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle(name))
+    report = validate_skill_file(skill_file)
+    assert (ERROR, "name") in fields(report), name
+
+
+def test_name_over_64_characters_is_an_error(tmp_path: Path) -> None:
+    name = "a" * 65
+    skill_file = write_skill(tmp_path, name, minimal_bundle(name))
+    assert (ERROR, "name") in fields(validate_skill_file(skill_file))
+
+
+def test_name_must_match_parent_directory(tmp_path: Path) -> None:
+    skill_file = write_skill(tmp_path, "actual-dir", minimal_bundle("other-name"))
+    report = validate_skill_file(skill_file)
+    assert (ERROR, "name") in fields(report)
+    assert "actual-dir" in report.findings[-1].message
+
+
+def test_non_string_name_is_an_error(tmp_path: Path) -> None:
+    skill_file = write_skill(tmp_path, "pdf-processing", "---\nname: [a, b]\ndescription: x\n---\n")
+    assert (ERROR, "name") in fields(validate_skill_file(skill_file))
+
+
+def test_non_string_description_and_compatibility_are_errors(tmp_path: Path) -> None:
+    text = (
+        "---\n"
+        "name: pdf-processing\n"
+        "description: [not, a, string]\n"
+        "compatibility: [also, not]\n"
+        "---\n"
+    )
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    report = validate_skill_file(skill_file)
+    assert (ERROR, "description") in fields(report)
+    assert (ERROR, "compatibility") in fields(report)
+
+
+def test_bare_metadata_line_is_not_an_error(tmp_path: Path) -> None:
+    # parse_simple_yaml represents a bare `metadata:` key as an empty list;
+    # an empty map declares nothing and violates nothing.
+    text = minimal_bundle("pdf-processing").replace("---\n\n", "metadata:\n---\n\n", 1)
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    assert validate_skill_file(skill_file).ok
+
+
+def test_oversized_body_token_estimate_is_a_warning(tmp_path: Path) -> None:
+    body = "\n" + ("detailed guidance for every edge case " * 600)
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle("pdf-processing") + body)
+    report = validate_skill_file(skill_file)
+    assert (WARNING, "body") in fields(report)
+    assert any("tokens" in finding.message for finding in report.warnings)
+
+
+def test_description_required_and_bounded(tmp_path: Path) -> None:
+    missing = write_skill(tmp_path / "a", "no-description", "---\nname: no-description\n---\n")
+    assert (ERROR, "description") in fields(validate_skill_file(missing))
+
+    long_dir = "long-description"
+    overlong = write_skill(
+        tmp_path / "b", long_dir, minimal_bundle(long_dir, description="x" * 1025)
+    )
+    assert (ERROR, "description") in fields(validate_skill_file(overlong))
+
+
+def test_short_description_is_a_warning(tmp_path: Path) -> None:
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle("pdf-processing", "Helps with PDFs."))
+    report = validate_skill_file(skill_file)
+    assert fields(report, ERROR) == []
+    assert (WARNING, "description") in fields(report)
+
+
+def test_compatibility_over_500_characters_is_an_error(tmp_path: Path) -> None:
+    text = minimal_bundle("pdf-processing").replace(
+        "---\n\n", f"compatibility: {'x' * 501}\n---\n\n", 1
+    )
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    assert (ERROR, "compatibility") in fields(validate_skill_file(skill_file))
+
+
+def test_metadata_values_must_be_strings(tmp_path: Path) -> None:
+    text = minimal_bundle("pdf-processing").replace(
+        "---\n\n", "metadata:\n  author: example-org\n  stable: true\n---\n\n", 1
+    )
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    report = validate_skill_file(skill_file)
+    assert (ERROR, "metadata") in fields(report)
+    assert "stable" in report.findings[0].message
+
+
+def test_metadata_must_be_a_mapping(tmp_path: Path) -> None:
+    text = minimal_bundle("pdf-processing").replace("---\n\n", "metadata: just-a-string\n---\n\n", 1)
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    assert (ERROR, "metadata") in fields(validate_skill_file(skill_file))
+
+
+def test_allowed_tools_must_be_a_string(tmp_path: Path) -> None:
+    text = minimal_bundle("pdf-processing").replace(
+        "---\n\n", "allowed-tools:\n  - Bash(git:*)\n  - Read\n---\n\n", 1
+    )
+    skill_file = write_skill(tmp_path, "pdf-processing", text)
+    assert (ERROR, "allowed-tools") in fields(validate_skill_file(skill_file))
+
+
+def test_overlong_body_is_a_warning(tmp_path: Path) -> None:
+    body = "\n".join(f"line {index} of guidance" for index in range(600))
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle("pdf-processing") + body)
+    report = validate_skill_file(skill_file)
+    assert (WARNING, "body") in fields(report)
+    assert fields(report, ERROR) == []
+
+
+def test_deep_and_escaping_references_are_warnings(tmp_path: Path) -> None:
+    body = (
+        "\nSee [deep](references/legal/REFERENCE.md), "
+        "[outside](../shared/common.md), and [absolute](/etc/passwd).\n"
+    )
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle("pdf-processing") + body)
+    report = validate_skill_file(skill_file)
+    messages = [finding.message for finding in report.findings if finding.field == "references"]
+    assert len(messages) == 3
+    assert fields(report, ERROR) == []
+
+
+def test_urls_and_anchors_are_not_file_references(tmp_path: Path) -> None:
+    body = "\nSee [the spec](https://agentskills.io/specification#frontmatter) and [mail](mailto:a@b.c).\n"
+    skill_file = write_skill(tmp_path, "pdf-processing", minimal_bundle("pdf-processing") + body)
+    assert validate_skill_file(skill_file).ok
+
+
+def test_validate_target_accepts_file_bundle_dir_and_root(tmp_path: Path) -> None:
+    skill_file = write_skill(tmp_path / "root", "pdf-processing", minimal_bundle("pdf-processing"))
+    assert len(validate_target(skill_file)) == 1
+    assert len(validate_target(skill_file.parent)) == 1
+    assert len(validate_target(tmp_path)) == 1
+    assert validate_root(tmp_path / "root")[0].ok
+
+
+def test_summarize_reports(tmp_path: Path) -> None:
+    write_skill(tmp_path, "good-skill", minimal_bundle("good-skill"))
+    write_skill(tmp_path, "bad-skill", "# nothing\n")
+    summary = summarize_reports(validate_root(tmp_path))
+    assert summary == {"bundles": 2, "ok": 1, "errors": 3, "warnings": 0}
+
+
+def test_repo_example_skills_are_spec_compliant() -> None:
+    examples = Path(__file__).parent.parent / "examples" / "skills"
+    reports = validate_root(examples)
+    assert reports, "expected the repo's example skills to be discovered"
+    for report in reports:
+        assert report.errors == [], f"{report.skill_path}: {report.errors}"


### PR DESCRIPTION
## What

Builds SkillRoute directly around the [Agent Skills open standard](https://agentskills.io/home) ([specification](https://agentskills.io/specification)) — the format SkillRoute has always indexed, now treated as a first-class contract:

- **`skillroute validate [paths]`** — a dependency-free checker for the spec. The frontmatter MUSTs report as **errors** (required `name`/`description`; the 64/1024/500-character bounds; the name charset, hyphen rules, and parent-directory match; `metadata` as a string→string map; `allowed-tools` as a space-separated string), and the progressive-disclosure recommendations report as **warnings** (description quality, body under 500 lines / ~5000 estimated tokens, file references one level deep and in-bundle). `--strict` fails on warnings too, `--json` is machine-readable, and a non-zero exit on errors makes it a CI gate.
- **Spec checks at index time** — `skillroute index` validates every bundle it discovers: errors are named on stderr and summarized, and the bundle is indexed anyway by default; `--strict` refuses non-compliant bundles so a catalog stays spec-clean by construction. Malformed-file isolation is unchanged.
- **Spec fields surfaced** — `skillroute inspect` now prints `license`, `compatibility`, `allowed-tools`, and the `metadata` map when a bundle declares them (they were already stored in `metadata_json`; no schema change).
- **Docs** — new [docs/spec-compliance.md](docs/spec-compliance.md) with the full rule set and the relationship to `skills-ref`; README gains a "Built on the Agent Skills open standard" section and CLI/Docs rows; getting-started shows `validate` in the five-minute flow.

Unknown top-level frontmatter fields are deliberately not flagged: the spec defines six fields but does not forbid others, and SkillRoute's own `tags`/relationship extensions are load-bearing.

## Verification

- 526 tests pass (490 on main + 36 new), including a test asserting the repo's own `examples/skills` validate with zero errors
- `ruff check` and `mypy` clean; `skillroute.spec` at 100% line+branch coverage, project total 90% (CI gate is 80%)
- Smoke-tested end to end: `validate` on clean and noncompliant bundles (text + JSON + exit codes), `index` in warn and strict modes

Co-Authored-By: Claude <noreply@anthropic.com>