### PR TITLE
chore(deps): stop Dependabot proposing TypeScript majors for /web

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,17 @@ updates:
     directory: "/web"
     schedule:
       interval: weekly
+    ignore:
+      # typescript-eslint hard-errors at import time on TypeScript 7 ("typescript-eslint
+      # does not support TS 7.0"), and every published version -- canaries included --
+      # pins the peer `typescript >=4.8.4 <6.1.0`. There is no combination that lints,
+      # so a TS major bump here can only turn CI red. Support is tracked upstream for
+      # TS >=7.1 in typescript-eslint/typescript-eslint#10940; drop this ignore then.
+      #
+      # This is scoped to /web on purpose: /mcp has no typescript-eslint and is already
+      # on typescript ^7.0.2 with a green MCP job.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: uv
     directory: "/"


### PR DESCRIPTION
Closes #65.

## Why

Dependabot #65 bumped `typescript` 6.0.3 → 7.0.2 in `/web` and turned both the **Web** and **Package** jobs red at `npm ci`:

```
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.1.0" from typescript-eslint@8.67.0
npm error Conflicting peer dependency: typescript@6.0.3
```

This looks like the plugin-react 6 / vite 7 case fixed in #54, but it is not. There the missing piece (vite 8) existed and just had not landed yet. Here **nothing published unblocks it**:

| package | latest | peer `typescript` |
|---|---|---|
| `typescript-eslint` | 8.67.0 | `>=4.8.4 <6.1.0` |
| `typescript-eslint` (canary) | 8.67.1-alpha.25 | `>=4.8.4 <6.1.0` |
| `@typescript-eslint/eslint-plugin` | 8.67.0 | `>=4.8.4 <6.1.0` |
| `@typescript-eslint/parser` | 8.67.0 | `>=4.8.4 <6.1.0` |
| `@typescript-eslint/typescript-estree` | 8.67.0 | `>=4.8.4 <6.1.0` |

And the peer range is not merely stale. Forcing the install with `--legacy-peer-deps` still fails, because the guard is a runtime one:

```
$ npm run lint
typescript-eslint does not support TS 7.0.
See also https://github.com/typescript-eslint/typescript-eslint/issues/10940
for tracking typescript-eslint's support for TS >=7.1

Error: typescript-eslint does not support TS 7.0.
    at Object.<anonymous> (node_modules/typescript-eslint/dist/index.js:52:11)
```

## What is actually fine

TypeScript 7 itself is not the problem. On the #65 branch with a forced install:

```
$ npm run typecheck   # tsc 7.0.2 -- clean, no output
$ npm run test        # Test Files 1 passed (1) / Tests 3 passed (3)
$ npm run build       # vite v8.2.1, 1957 modules transformed, built in 294ms
```

`/mcp` is already on `typescript: ^7.0.2` with a green **MCP** job, precisely because it has no typescript-eslint. The blocker is one dependency in one workspace, and it is upstream.

## The change

Ignore only `version-update:semver-major` for `typescript` in the `/web` entry. 6.x patch and minor bumps keep flowing, and `/mcp` is deliberately untouched.

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML and still declares all four update entries
- [x] Reproduced the #65 `npm ci` ERESOLVE locally on a clean checkout
- [x] Confirmed `--legacy-peer-deps` does not rescue it (`npm run lint` fails at import)
- [x] Confirmed typecheck / test / build pass under TS 7, isolating the failure to typescript-eslint
- [ ] Dependabot no longer opens a TS 7 PR for `/web` on the next weekly run

## Follow-up

Drop the ignore once typescript-eslint/typescript-eslint#10940 ships, then bump `typescript` and `typescript-eslint` in the same PR — the way vite 8 and plugin-react 6 had to move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
