### PR TITLE
chore: release 0.4.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-21
+
 ### Added
 
 - **Agent Skills spec compliance.** SkillRoute now treats the
@@ -83,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `skillroute stats` on a catalog that was never indexed reports zero routes
   instead of failing with a missing-table SQL error.
 
-[Unreleased]: https://github.com/erichare/skillroute/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/erichare/skillroute/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/erichare/skillroute/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/erichare/skillroute/compare/v0.2.0...v0.3.0
 
 ## [0.2.0] - 2026-08-13

--- a/dsh-plugin/package.json
+++ b/dsh-plugin/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@skillroute/dsh-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "DeepSeek Harness (dsh) bundle wiring SkillRoute's skill router into your agents.",
   "license": "MIT",
   "author": "Eric Hare",
-  "homepage": "https://github.com/erichare/skill-route#readme",
+  "homepage": "https://github.com/erichare/skillroute#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/erichare/skill-route.git",
+    "url": "git+https://github.com/erichare/skillroute.git",
     "directory": "dsh-plugin"
   },
   "bugs": {
-    "url": "https://github.com/erichare/skill-route/issues"
+    "url": "https://github.com/erichare/skillroute/issues"
   },
   "keywords": [
     "dsh-plugin",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillroute/mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "SkillRoute MCP stdio server",
   "license": "MIT",
   "author": "Eric Hare",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skillroute"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local-first skill catalog and router for agent builders"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "skillroute"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Replaces `chore/release-0.4.0`, which was 7 commits behind main and could not be
updated in place. Same content, rebased onto current main, with the co-author
trailer dropped.

## What this carries

The 0.4.0 release prep. None of it is on main yet, so it is required before a
`v0.4.0` tag can be cut.

- `pyproject.toml`, `mcp/package.json`, `dsh-plugin/package.json` → `0.4.0`.
  These are the exact three the release workflow's tag guard compares against
  the tag; a mismatch aborts the publish, which matters because a PyPI version
  can never be reused.
- The `[0.4.0]` changelog section, dated 2026-08-21, covering the Agent Skills
  spec work from #66 and the `dsh` bundle from `8516346`, plus the compare links.
- `dsh-plugin`'s `homepage` / `repository` / `bugs` URLs corrected from the
  pre-rename `erichare/skill-route`. That manifest was added after #52, so it
  missed the rename sweep.

## Second commit: attribution

`.claude/settings.json` sets `includeCoAuthoredBy: false`, which stops the
`Co-Authored-By: Claude` trailer on commits and the "Generated with Claude Code"
footer on PR bodies. The user-level setting meant to do this was never actually
set, so the default (on) had been in effect — that is why 20 trailers exist
across 13 commits already on main.

Those stay as they are. Rewriting them means force-pushing main, which the
ruleset blocks and which would invalidate every existing commit reference.

## Test plan

- [x] Cherry-pick onto current main applies cleanly — the release commit touches
      only the changelog and three manifests, none of which the 7 intervening
      commits touched
- [x] All three manifests read `0.4.0`, so the tag guard for `v0.4.0` passes
- [x] No `erichare/skill-route` references remain outside lockfiles
- [ ] CI green on this branch
- [ ] After merge: tag `v0.4.0` and confirm the release workflow publishes

## Note

Once this merges, `chore/release-0.4.0` is superseded and can be deleted.
