### PR TITLE
ci: make the release workflow re-runnable against an existing tag

### DIFF
--- a/.github/scripts/npm-publish-if-new.sh
+++ b/.github/scripts/npm-publish-if-new.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Publish the npm package in the working directory, unless that exact version is
+# already on the registry.
+#
+# Without this, recovering a half-failed release is impossible: the npm job
+# publishes two packages in sequence, and if the second one fails, re-running
+# replays the first, which exits non-zero with "You cannot publish over the
+# previously published versions" and the second never runs again.
+set -euo pipefail
+
+name=$(node -p "require('./package.json').name")
+version=$(node -p "require('./package.json').version")
+
+# `npm view <pkg>@<version> version` exits non-zero when that version does not
+# exist, which is the whole test. 2>/dev/null because the miss is expected.
+if npm view "$name@$version" version >/dev/null 2>&1; then
+  echo "$name@$version is already on the registry; skipping publish."
+else
+  echo "Publishing $name@$version"
+  npm publish
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,27 @@ on:
   push:
     tags: ["v*"]
 
+  # A release can half-succeed: v0.4.0 reached PyPI, the GitHub release, and
+  # @skillroute/mcp-server, but @skillroute/dsh-plugin failed because it had no
+  # npm trusted publisher configured. Re-running the original run does not
+  # recover that -- it replays the steps that already succeeded, and every
+  # publisher refuses to overwrite an existing version, so the job dies before
+  # reaching the one that still needs to run. Recovery needs a dispatch that
+  # targets an existing tag, which is why every publish step below is a no-op
+  # when its version is already live.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to publish, e.g. v0.4.0"
+        required: true
+        type: string
+
 permissions:
   contents: read
+
+env:
+  # On a tag push this is the pushed tag; on a dispatch it is the requested one.
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   build:
@@ -14,6 +33,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
@@ -35,13 +56,13 @@ jobs:
       # reused, so there is no clean recovery.
       - name: Verify the tag matches all package versions
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          tag="${RELEASE_TAG#v}"
           py=$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
           mcp_version=$(node -p "require('./mcp/package.json').version")
           plugin_version=$(node -p "require('./dsh-plugin/package.json').version")
           echo "tag=$tag pyproject=$py mcp=$mcp_version dsh-plugin=$plugin_version"
           if [ "$tag" != "$py" ] || [ "$tag" != "$mcp_version" ] || [ "$tag" != "$plugin_version" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME disagrees with pyproject.toml ($py), mcp/package.json ($mcp_version), and/or dsh-plugin/package.json ($plugin_version)."
+            echo "::error::Tag $RELEASE_TAG disagrees with pyproject.toml ($py), mcp/package.json ($mcp_version), and/or dsh-plugin/package.json ($plugin_version)."
             exit 1
           fi
 
@@ -79,6 +100,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -90,9 +113,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" dist/* \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; refreshing its artifacts."
+            gh release upload "$RELEASE_TAG" dist/* --clobber
+          else
+            gh release create "$RELEASE_TAG" dist/* \
+              --title "$RELEASE_TAG" \
+              --generate-notes
+          fi
 
   pypi:
     name: Publish to PyPI
@@ -114,6 +142,10 @@ jobs:
 
       - name: Publish via trusted publishing
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # A PyPI version can never be reused, so re-publishing is always a
+          # no-op rather than something worth failing the job over.
+          skip-existing: true
 
   npm:
     name: Publish npm packages
@@ -127,6 +159,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       # Trusted publishing needs npm >= 11.5.1. Node 22 bundles npm 10.x even at
       # its latest patch, so it cannot be used here; Node 24 bundles 11.17+,
@@ -146,8 +180,8 @@ jobs:
         working-directory: mcp
         run: |
           npm ci
-          npm publish
+          ../.github/scripts/npm-publish-if-new.sh
 
       - name: Publish dsh plugin
         working-directory: dsh-plugin
-        run: npm publish
+        run: ../.github/scripts/npm-publish-if-new.sh


### PR DESCRIPTION
## Why

v0.4.0 half-shipped. PyPI, the GitHub release, and `@skillroute/mcp-server` all succeeded. `@skillroute/dsh-plugin` failed:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@skillroute%2fdsh-plugin
```

The package had no npm trusted publisher configured — it was first published by hand on 2026-08-15, *after* the v0.3.0 tag, so it never got wired to OIDC. npm answers an unauthorized OIDC publish with 404 rather than 403 so it doesn't leak whether a package exists. That is now fixed on npmjs.com.

But fixing it was not enough, because **there was no way to run just the failed publish**:

- Re-running the run replays the whole job. Its first step publishes the MCP server, already at 0.4.0, which exits with `You cannot publish over the previously published versions: 0.4.0.` — so the dsh-plugin step is skipped and can never be reached. Confirmed by an actual re-run.
- Editing this workflow on `main` does not change a re-run either: a re-run uses the workflow as of the tagged commit.

So a version that failed to publish was simply stranded. That is the real defect, and it is what this fixes.

## What changed

**A `workflow_dispatch` trigger taking an existing tag.** Dispatching from `main` runs `main`'s copy of this workflow while checking out the *tag's* tree — which is what lets a fix to the release process apply to a release already cut. Every job now checks out `RELEASE_TAG` (`inputs.tag` on dispatch, `github.ref_name` on a tag push) instead of the triggering ref, and the version guard compares against it.

**Publish steps that no-op when their version is already live:**

| target | before | after |
|---|---|---|
| PyPI | fails if version exists | `skip-existing: true` |
| GitHub release | `gh release create` fails if it exists | create, or upload artifacts to the existing release |
| npm (both packages) | `npm publish` fails if version exists | `.github/scripts/npm-publish-if-new.sh` checks the registry first |

## Test plan

- [x] `release.yml` parses as valid YAML; both triggers, the `tag` input, and `RELEASE_TAG` resolve as expected
- [x] All three checkout steps pin `ref: ${{ env.RELEASE_TAG }}`; no `GITHUB_REF_NAME` references remain
- [x] `npm-publish-if-new.sh` passes `bash -n`, and against the **live registry** it skips `@skillroute/mcp-server@0.4.0` and publishes `@skillroute/dsh-plugin@0.4.0` (verified with a stubbed `npm publish`)
- [ ] After merge: dispatch this workflow against `v0.4.0` — expect PyPI skipped, GitHub release refreshed, mcp-server skipped, dsh-plugin published

## Note

The tag guard still runs on dispatch, so dispatching a tag whose manifests disagree with it still aborts before anything publishes. Idempotence is about not failing on work already done, not about loosening that check.
